### PR TITLE
fix(release): lowercase GitHub org momics in package metadata (npm E422)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/Momics/iroh-http"
+repository = "https://github.com/momics/iroh-http"
 
 [workspace.dependencies]
 iroh = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iroh-http
 
-[![CI](https://github.com/Momics/iroh-http/actions/workflows/ci.yml/badge.svg)](https://github.com/Momics/iroh-http/actions/workflows/ci.yml)
+[![CI](https://github.com/momics/iroh-http/actions/workflows/ci.yml/badge.svg)](https://github.com/momics/iroh-http/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@momics/iroh-http-node)](https://www.npmjs.com/package/@momics/iroh-http-node)
 [![JSR](https://jsr.io/badges/@momics/iroh-http-deno)](https://jsr.io/@momics/iroh-http-deno)
 [![crates.io](https://img.shields.io/crates/v/iroh-http-core)](https://crates.io/crates/iroh-http-core)

--- a/packages/iroh-http-deno/src/adapter.ts
+++ b/packages/iroh-http-deno/src/adapter.ts
@@ -57,7 +57,7 @@ function libName(): string {
 /** Version must match the tag used for GitHub releases (v0.1.0 → tag v0.1.0). */
 const VERSION = "0.5.0";
 const DOWNLOAD_BASE =
-  `https://github.com/Momics/iroh-http/releases/download/v${VERSION}`;
+  `https://github.com/momics/iroh-http/releases/download/v${VERSION}`;
 
 function cacheDir(): string {
   // Local dev: import.meta.url is file://, use lib/ next to src/.

--- a/packages/iroh-http-node/npm/darwin-arm64/package.json
+++ b/packages/iroh-http-node/npm/darwin-arm64/package.json
@@ -8,5 +8,5 @@
   "files": ["iroh-http-node.darwin-arm64.node"],
   "license": "(MIT OR Apache-2.0)",
   "publishConfig": { "access": "public" },
-  "repository": { "type": "git", "url": "git+https://github.com/Momics/iroh-http.git" }
+  "repository": { "type": "git", "url": "git+https://github.com/momics/iroh-http.git" }
 }

--- a/packages/iroh-http-node/npm/darwin-x64/package.json
+++ b/packages/iroh-http-node/npm/darwin-x64/package.json
@@ -8,5 +8,5 @@
   "files": ["iroh-http-node.darwin-x64.node"],
   "license": "(MIT OR Apache-2.0)",
   "publishConfig": { "access": "public" },
-  "repository": { "type": "git", "url": "git+https://github.com/Momics/iroh-http.git" }
+  "repository": { "type": "git", "url": "git+https://github.com/momics/iroh-http.git" }
 }

--- a/packages/iroh-http-node/npm/linux-arm64-gnu/package.json
+++ b/packages/iroh-http-node/npm/linux-arm64-gnu/package.json
@@ -8,5 +8,5 @@
   "files": ["iroh-http-node.linux-arm64-gnu.node"],
   "license": "(MIT OR Apache-2.0)",
   "publishConfig": { "access": "public" },
-  "repository": { "type": "git", "url": "git+https://github.com/Momics/iroh-http.git" }
+  "repository": { "type": "git", "url": "git+https://github.com/momics/iroh-http.git" }
 }

--- a/packages/iroh-http-node/npm/linux-x64-gnu/package.json
+++ b/packages/iroh-http-node/npm/linux-x64-gnu/package.json
@@ -8,5 +8,5 @@
   "files": ["iroh-http-node.linux-x64-gnu.node"],
   "license": "(MIT OR Apache-2.0)",
   "publishConfig": { "access": "public" },
-  "repository": { "type": "git", "url": "git+https://github.com/Momics/iroh-http.git" }
+  "repository": { "type": "git", "url": "git+https://github.com/momics/iroh-http.git" }
 }

--- a/packages/iroh-http-node/npm/win32-x64-msvc/package.json
+++ b/packages/iroh-http-node/npm/win32-x64-msvc/package.json
@@ -8,5 +8,5 @@
   "files": ["iroh-http-node.win32-x64-msvc.node"],
   "license": "(MIT OR Apache-2.0)",
   "publishConfig": { "access": "public" },
-  "repository": { "type": "git", "url": "git+https://github.com/Momics/iroh-http.git" }
+  "repository": { "type": "git", "url": "git+https://github.com/momics/iroh-http.git" }
 }

--- a/packages/iroh-http-node/package.json
+++ b/packages/iroh-http-node/package.json
@@ -57,7 +57,7 @@
   "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Momics/iroh-http"
+    "url": "https://github.com/momics/iroh-http"
   },
-  "homepage": "https://github.com/Momics/iroh-http"
+  "homepage": "https://github.com/momics/iroh-http"
 }

--- a/packages/iroh-http-shared/package.json
+++ b/packages/iroh-http-shared/package.json
@@ -30,7 +30,7 @@
   "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Momics/iroh-http"
+    "url": "https://github.com/momics/iroh-http"
   },
-  "homepage": "https://github.com/Momics/iroh-http"
+  "homepage": "https://github.com/momics/iroh-http"
 }

--- a/packages/iroh-http-tauri/Cargo.toml
+++ b/packages/iroh-http-tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.77.2"
 description = "Tauri plugin for iroh-http peer-to-peer HTTP"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/Momics/iroh-http"
+repository = "https://github.com/momics/iroh-http"
 readme = "README.md"
 links = "tauri-plugin-iroh-http"
 

--- a/packages/iroh-http-tauri/package.json
+++ b/packages/iroh-http-tauri/package.json
@@ -37,7 +37,7 @@
   "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Momics/iroh-http"
+    "url": "https://github.com/momics/iroh-http"
   },
-  "homepage": "https://github.com/Momics/iroh-http"
+  "homepage": "https://github.com/momics/iroh-http"
 }


### PR DESCRIPTION
0.5.0 npm publish now authenticates via Trusted Publishing (PR #241), but fails provenance verification with **E422**: package.json `repository.url` used `Momics/iroh-http` while GitHub OIDC provenance reports the canonical lowercase `momics/iroh-http`.

Lowercases the org in all published `package.json` (3 main + 5 node platform packages), the Deno adapter download URL, `Cargo.toml` repository fields, and the README CI badge.

After merge: re-dispatch Publish `target=npm run_id=28154472065`.