### PR TITLE
fix(node): make mdns_advertise async to stop --test-force-exit SIGABRT (#243)

### DIFF
--- a/packages/iroh-http-node/index.d.ts
+++ b/packages/iroh-http-node/index.d.ts
@@ -270,8 +270,16 @@ export declare function jsTryNextChunk(endpointHandle: number, handle: bigint): 
 /**
  * Start advertising this node on the local network via mDNS.
  * Returns an advertise handle.
+ *
+ * Declared `async` so napi runs it inside the global Tokio runtime. The mDNS
+ * address-lookup constructor calls `tokio::runtime::Handle::current()`, which
+ * panics outside a runtime context. A synchronous binding ran on the bare JS
+ * thread and could panic—aborting the process under `panic = "abort"`—when
+ * invoked from a late promise continuation during `--test-force-exit` teardown
+ * (issue #243). Running inside the runtime keeps the handle valid and lets
+ * post-shutdown calls reject gracefully instead of aborting.
  */
-export declare function mdnsAdvertise(endpointHandle: number, serviceName: string): number
+export declare function mdnsAdvertise(endpointHandle: number, serviceName: string): Promise<number>
 
 /** Stop advertising this node on the local network. */
 export declare function mdnsAdvertiseClose(advertiseHandle: number): void

--- a/packages/iroh-http-node/src/lib.rs
+++ b/packages/iroh-http-node/src/lib.rs
@@ -641,9 +641,17 @@ pub fn mdns_browse_close(_browse_handle: u32) {}
 
 /// Start advertising this node on the local network via mDNS.
 /// Returns an advertise handle.
+///
+/// Declared `async` so napi runs it inside the global Tokio runtime. The mDNS
+/// address-lookup constructor calls `tokio::runtime::Handle::current()`, which
+/// panics outside a runtime context. A synchronous binding ran on the bare JS
+/// thread and could panic—aborting the process under `panic = "abort"`—when
+/// invoked from a late promise continuation during `--test-force-exit` teardown
+/// (issue #243). Running inside the runtime keeps the handle valid and lets
+/// post-shutdown calls reject gracefully instead of aborting.
 #[napi]
 #[cfg(feature = "discovery")]
-pub fn mdns_advertise(endpoint_handle: u32, service_name: String) -> napi::Result<u32> {
+pub async fn mdns_advertise(endpoint_handle: u32, service_name: String) -> napi::Result<u32> {
     let ep = get_endpoint(endpoint_handle)?;
     validate_bounded_string("serviceName", &service_name, MAX_MDNS_SERVICE_NAME_LEN)
         .map_err(ffi_invalid_arg)?;
@@ -655,7 +663,7 @@ pub fn mdns_advertise(endpoint_handle: u32, service_name: String) -> napi::Resul
 
 #[napi]
 #[cfg(not(feature = "discovery"))]
-pub fn mdns_advertise(_endpoint_handle: u32, _service_name: String) -> napi::Result<u32> {
+pub async fn mdns_advertise(_endpoint_handle: u32, _service_name: String) -> napi::Result<u32> {
     Err(napi::Error::new(
         Status::GenericFailure,
         format_error_json("UNKNOWN", "discovery feature not enabled in this build"),


### PR DESCRIPTION
## Summary

Fixes #243 — the Node **Extended-tests** flake. The native `mdns_advertise`
binding was **synchronous**, but the mDNS address-lookup constructor calls
`tokio::runtime::Handle::current()`, which **panics outside a Tokio runtime
context**. When a late promise continuation invoked `mdns_advertise` during
`node --test --test-force-exit` teardown — after the runtime was already gone —
the panic aborted the process with **SIGABRT** (the addon is built with
`panic = "abort"`). node:test then reported the file-level test as failed even
though all 69 functional subtests passed.

## Root cause (symbolized backtrace)

```
panic: "there is no reactor running, must be called from a Tokio 1.x runtime"
  tokio::runtime::scheduler::Handle::current
  iroh_mdns_address_lookup::MdnsAddressLookup::new
  iroh_http_discovery::start_advertise
  iroh_http_node::mdns_advertise            ← synchronous napi binding
  …PromiseFulfillReactionJob (microtask during --test-force-exit teardown)
```

## Fix

Declare `mdns_advertise` **`async`** (matching the existing `mdns_browse`), so
napi runs it inside the global Tokio runtime where `Handle::current()` is valid,
and post-shutdown invocations reject gracefully instead of aborting.

The JS adapter wrapper already returns `Promise<number>` and all callers already
`await` it, so the change is signature-compatible — the only generated change is
the `index.d.ts` return type (`number` → `Promise<number>`).

## Verification

- `node --test --test-force-exit tests/runners/node.mjs` — **5/5 clean runs**,
  70/70 tests pass (previously a deterministic file-level failure).
- Node package self-test: **93 passed, 0 failed**.
- `cargo clippy -p iroh-http-node --all-targets` — clean.

## Scope

- Node adapter only. Deno is unaffected (separate FFI path, already green).
- No public API change; no version bump in this PR.
