### PR TITLE
fix: guard u64 handle precision loss at Deno rawFetch and Tauri FFI boundary

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.16",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/fs@1": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.13",
@@ -16,6 +17,12 @@
     "npm:vitest@^4.1.9": "4.1.9_@types+node@25.6.0_jsdom@29.1.0_vite@8.1.0__@types+node@25.6.0"
   },
   "jsr": {
+    "@std/assert@1.0.16": {
+      "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },

--- a/packages/iroh-http-deno/src/adapter.ts
+++ b/packages/iroh-http-deno/src/adapter.ts
@@ -289,25 +289,29 @@ const METHOD_BUFS: Record<string, Uint8Array> = Object.fromEntries(
   ].map((m) => [m, enc.encode(m)]),
 );
 
+// ISS-032 / #252: bigint handles are slotmap u64 keys (32-bit slot + 32-bit
+// version); practical values are well within Number.MAX_SAFE_INTEGER. Convert
+// to a JS number only after asserting the safe range, throwing early rather
+// than silently corrupting resource identity. Shared by the generic `call()`
+// path and the `rawFetch` fast-path so both fail loudly and identically.
+export function bigintToSafeNumber(value: bigint, field = "handle"): number {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new RangeError(
+      `[iroh-http] ${field} value ${value} exceeds safe integer range and cannot be safely serialised`,
+    );
+  }
+  return Number(value);
+}
+
 /** Reusable buffer hint for estimating output size of `call()` responses. */ async function call<
   T,
 >(method: string, payload: unknown): Promise<T> {
   const methodBuf = METHOD_BUFS[method] ?? enc.encode(method);
-  // ISS-032: bigint handles are slotmap u64 keys (32-bit slot + 32-bit version);
-  // practical values are well within Number.MAX_SAFE_INTEGER. Throw early if a
-  // handle ever exceeds the safe range rather than silently corrupting identity.
   const payloadBuf = enc.encode(
-    JSON.stringify(payload, (_k, v) => {
-      if (typeof v === "bigint") {
-        if (v > BigInt(Number.MAX_SAFE_INTEGER)) {
-          throw new RangeError(
-            `[iroh-http] handle value ${v} exceeds safe integer range and cannot be safely serialised`,
-          );
-        }
-        return Number(v);
-      }
-      return v;
-    }),
+    JSON.stringify(
+      payload,
+      (_k, v) => typeof v === "bigint" ? bigintToSafeNumber(v) : v,
+    ),
   );
   // Deno's FFI types require Uint8Array<ArrayBuffer>; TextEncoder returns
   // Uint8Array<ArrayBufferLike>. The backing store is always a plain ArrayBuffer
@@ -530,14 +534,18 @@ export const rawFetch: RawFetchFn = async (
       url,
       method,
       headers,
-      reqBodyHandle: reqBodyHandle != null ? Number(reqBodyHandle) : null,
-      fetchToken: fetchToken !== 0n ? Number(fetchToken) : null,
+      reqBodyHandle: reqBodyHandle != null
+        ? bigintToSafeNumber(reqBodyHandle, "reqBodyHandle")
+        : null,
+      fetchToken: fetchToken !== 0n
+        ? bigintToSafeNumber(fetchToken, "fetchToken")
+        : null,
       directAddrs: directAddrs ?? null,
       timeout_ms: fetchOptions?.timeoutMs ?? null,
       decompress: fetchOptions?.decompress ?? null,
       max_response_body_bytes: fetchOptions?.maxResponseBodyBytes ?? null,
     },
-    (_k, v) => (typeof v === "bigint" ? Number(v) : v),
+    (_k, v) => (typeof v === "bigint" ? bigintToSafeNumber(v) : v),
   );
   const payloadBuf = enc.encode(payloadStr) as Uint8Array<ArrayBuffer>;
 

--- a/packages/iroh-http-deno/test/adapter.test.ts
+++ b/packages/iroh-http-deno/test/adapter.test.ts
@@ -11,9 +11,38 @@
  * Run:  deno test -A test/adapter.test.ts
  */
 
-import { assert, assertEquals, assertInstanceOf } from "jsr:@std/assert@^1";
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertThrows,
+} from "jsr:@std/assert@^1";
 import { createNode } from "../mod.ts";
 import { generateSecretKey, publicKeyVerify, secretKeySign } from "../mod.ts";
+import { bigintToSafeNumber } from "../src/adapter.ts";
+
+// ── bigintToSafeNumber handle guard (regression #252) ────────────────────────
+
+Deno.test("bigintToSafeNumber — passes through in-range handles", () => {
+  assertEquals(bigintToSafeNumber(0n), 0);
+  assertEquals(bigintToSafeNumber(42n), 42);
+  assertEquals(
+    bigintToSafeNumber(BigInt(Number.MAX_SAFE_INTEGER)),
+    Number.MAX_SAFE_INTEGER,
+  );
+});
+
+Deno.test("bigintToSafeNumber — rejects out-of-range u64 handles instead of truncating", () => {
+  // A slotmap u64 key whose generation bits push it past 2^53 must throw,
+  // not silently round to a different (wrong) resource identity.
+  const unsafe = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+  assertThrows(
+    () => bigintToSafeNumber(unsafe, "reqBodyHandle"),
+    RangeError,
+    "reqBodyHandle",
+  );
+  assertThrows(() => bigintToSafeNumber(-1n), RangeError);
+});
 
 // ── generateSecretKey (FFI-only) ─────────────────────────────────────────────
 

--- a/packages/iroh-http-tauri/guest-js/index.ts
+++ b/packages/iroh-http-tauri/guest-js/index.ts
@@ -41,6 +41,21 @@ interface TauriRequestPayload {
   remoteNodeId: string;
 }
 
+/**
+ * Convert an opaque u64 resource handle (slotmap key: 32-bit slot + 32-bit
+ * generation) to a JS number for IPC, rejecting values outside the safe
+ * integer range rather than silently rounding and addressing the wrong
+ * resource. Mirrors the Deno adapter's `bigintToSafeNumber` guard (#252).
+ */
+function u64Handle(value: bigint, field = "handle"): number {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new RangeError(
+      `[iroh-http-tauri] ${field} value ${value} exceeds safe integer range and cannot be safely serialised`,
+    );
+  }
+  return Number(value);
+}
+
 // ── TauriAdapter ──────────────────────────────────────────────────────────────
 
 class TauriAdapter extends IrohAdapter {
@@ -56,9 +71,10 @@ class TauriAdapter extends IrohAdapter {
   nextChunk(handle: bigint): Promise<Uint8Array | null> {
     // Sync fast path: if data is already buffered, skip async IPC overhead.
     // Protocol: first byte is 0x01 (data follows) or 0x00 (EOF).
+    const safeHandle = u64Handle(handle);
     return invoke<ArrayBuffer>(`${PLUGIN}|try_next_chunk`, {
       endpointHandle: this.#epHandle,
-      handle: Number(handle),
+      handle: safeHandle,
     }).then(
       (buf) => {
         const v = new Uint8Array(buf);
@@ -68,7 +84,7 @@ class TauriAdapter extends IrohAdapter {
       () =>
         invoke<ArrayBuffer>(`${PLUGIN}|next_chunk`, {
           endpointHandle: this.#epHandle,
-          handle: Number(handle),
+          handle: safeHandle,
         }).then((buf) => {
           const v = new Uint8Array(buf);
           return v.length > 0 && v[0] !== 0 ? v.subarray(1) : null;
@@ -80,7 +96,7 @@ class TauriAdapter extends IrohAdapter {
     return invoke(`${PLUGIN}|send_chunk`, chunk, {
       headers: {
         "iroh-ep": String(this.#epHandle),
-        "iroh-handle": String(Number(handle)),
+        "iroh-handle": String(u64Handle(handle)),
       },
     });
   }
@@ -88,14 +104,14 @@ class TauriAdapter extends IrohAdapter {
   finishBody(handle: bigint): Promise<void> {
     return invoke(`${PLUGIN}|finish_body`, {
       endpointHandle: this.#epHandle,
-      handle: Number(handle),
+      handle: u64Handle(handle),
     });
   }
 
   cancelRequest(handle: bigint): Promise<void> {
     return invoke(`${PLUGIN}|cancel_request`, {
       endpointHandle: this.#epHandle,
-      handle: Number(handle),
+      handle: u64Handle(handle),
     });
   }
 
@@ -107,7 +123,7 @@ class TauriAdapter extends IrohAdapter {
   cancelFetch(token: bigint): void {
     void invoke(`${PLUGIN}|cancel_in_flight`, {
       endpointHandle: this.#epHandle,
-      token: Number(token),
+      token: u64Handle(token, "token"),
     });
   }
 
@@ -140,8 +156,12 @@ class TauriAdapter extends IrohAdapter {
         url,
         method,
         headers,
-        reqBodyHandle: reqBodyHandle != null ? Number(reqBodyHandle) : null,
-        fetchToken: fetchToken != null ? Number(fetchToken) : null,
+        reqBodyHandle: reqBodyHandle != null
+          ? u64Handle(reqBodyHandle, "reqBodyHandle")
+          : null,
+        fetchToken: fetchToken != null
+          ? u64Handle(fetchToken, "fetchToken")
+          : null,
         directAddrs: directAddrs ?? null,
         timeoutMs: fetchOptions?.timeoutMs ?? null,
         decompress: fetchOptions?.decompress ?? null,
@@ -191,7 +211,7 @@ class TauriAdapter extends IrohAdapter {
         await invoke(`${PLUGIN}|respond_to_request`, {
           args: {
             endpointHandle: Number(endpointHandle),
-            reqHandle: Number(payload.reqHandle),
+            reqHandle: u64Handle(payload.reqHandle, "reqHandle"),
             status: head.status,
             headers: head.headers,
           },
@@ -201,7 +221,7 @@ class TauriAdapter extends IrohAdapter {
         await invoke(`${PLUGIN}|respond_to_request`, {
           args: {
             endpointHandle: Number(endpointHandle),
-            reqHandle: Number(raw.reqHandle),
+            reqHandle: u64Handle(BigInt(raw.reqHandle), "reqHandle"),
             status: 500,
             headers: [],
           },


### PR DESCRIPTION
## Summary

Opaque `bigint` handles are slotmap `u64` keys (32-bit slot index + 32-bit generation). Two FFI paths converted them to JS `number` via raw `Number(...)` with no safe-range check, so a handle above `2^53` would silently round and address the wrong resource. The generic Deno `call()` path already guarded this exact case, making these two paths inconsistent outliers.

Closes #252.

## Changes

- **Deno** (`packages/iroh-http-deno/src/adapter.ts`): extracted a shared `bigintToSafeNumber()` guard and used it in both the generic `call()` replacer and the `rawFetch` fast-path, so the fast-path now throws `RangeError` like the slow path instead of silently truncating.
- **Tauri guest-js** (`packages/iroh-http-tauri/guest-js/index.ts`): added a `u64Handle()` boundary guard and applied it to every opaque `bigint` handle/token site (`nextChunk`, `sendChunk`, `finishBody`, `cancelRequest`, `cancelFetch`, `rawFetch`, `respond_to_request`). Endpoint handles are u32 `number`s and were left unchanged.
- **Tests** (`packages/iroh-http-deno/test/adapter.test.ts`): added regression tests asserting out-of-range handles are rejected rather than silently truncated.
- `deno.lock`: resolved `@std/assert` entry pulled in by the new test's `assertThrows`.

## Verification

- New Deno regression tests pass.
- `npm run typecheck` clean across all packages.
- `deno fmt` applied.

## Notes / out of scope

- This PR addresses only the precision-loss class. The audit's Tauri `rawServe()` handler-drain gap (no tracking of pending handler promises, unlike Deno's `await Promise.allSettled([...pending])`) is intentionally **not** included — it needs the Rust-side serve drain semantics confirmed first and will be filed separately.
- The audit's claimed Deno `iroh_http_start_fetch_cb` callback race was investigated and dismissed: the FFI symbol is blocking and `fetchResolvers.set` runs synchronously before the `await`, so the cross-thread callback cannot be delivered first.
- The Tauri fix takes the "reject unsafe values before IPC" route (consistent with the existing Node/Deno guard) rather than the larger "transport handles as decimal strings + parse `u64` in Rust" change, which would touch every plugin command signature.