### PR TITLE
fix(tauri): drain pending handler promises on serve shutdown

### DIFF
--- a/packages/iroh-http-tauri/guest-js/index.ts
+++ b/packages/iroh-http-tauri/guest-js/index.ts
@@ -195,38 +195,50 @@ class TauriAdapter extends IrohAdapter {
       connChannel = new Channel<PeerConnectionEvent>();
     }
 
-    channel.onmessage = async (raw: TauriRequestPayload) => {
-      const payload: RequestPayload = {
-        reqHandle: BigInt(raw.reqHandle),
-        reqBodyHandle: BigInt(raw.reqBodyHandle),
-        resBodyHandle: BigInt(raw.resBodyHandle),
-        method: raw.method,
-        url: raw.url,
-        headers: raw.headers as [string, string][],
-        remoteNodeId: raw.remoteNodeId,
-      };
+    // Track in-flight handler tasks so shutdown drains them before resolving,
+    // matching the Node/Deno serve contract. The Rust dispatch callback is
+    // fire-and-forget (it only sends the request event onto the channel and
+    // returns), so `wait_serve_stop()` alone does not guarantee JS handler
+    // promises — and their follow-up `respond_to_request` IPC — have settled.
+    const pending = new Set<Promise<void>>();
 
-      try {
-        const head = await callback(payload);
-        await invoke(`${PLUGIN}|respond_to_request`, {
-          args: {
-            endpointHandle: Number(endpointHandle),
-            reqHandle: u64Handle(payload.reqHandle, "reqHandle"),
-            status: head.status,
-            headers: head.headers,
-          },
-        });
-      } catch (err) {
-        console.error("[iroh-http-tauri] handler error:", err);
-        await invoke(`${PLUGIN}|respond_to_request`, {
-          args: {
-            endpointHandle: Number(endpointHandle),
-            reqHandle: u64Handle(BigInt(raw.reqHandle), "reqHandle"),
-            status: 500,
-            headers: [],
-          },
-        }).catch(() => {});
-      }
+    channel.onmessage = (raw: TauriRequestPayload) => {
+      const task = (async () => {
+        const payload: RequestPayload = {
+          reqHandle: BigInt(raw.reqHandle),
+          reqBodyHandle: BigInt(raw.reqBodyHandle),
+          resBodyHandle: BigInt(raw.resBodyHandle),
+          method: raw.method,
+          url: raw.url,
+          headers: raw.headers as [string, string][],
+          remoteNodeId: raw.remoteNodeId,
+        };
+
+        try {
+          const head = await callback(payload);
+          await invoke(`${PLUGIN}|respond_to_request`, {
+            args: {
+              endpointHandle: Number(endpointHandle),
+              reqHandle: u64Handle(payload.reqHandle, "reqHandle"),
+              status: head.status,
+              headers: head.headers,
+            },
+          });
+        } catch (err) {
+          console.error("[iroh-http-tauri] handler error:", err);
+          await invoke(`${PLUGIN}|respond_to_request`, {
+            args: {
+              endpointHandle: Number(endpointHandle),
+              reqHandle: u64Handle(BigInt(raw.reqHandle), "reqHandle"),
+              status: 500,
+              headers: [],
+            },
+          }).catch(() => {});
+        }
+      })();
+
+      pending.add(task);
+      task.finally(() => pending.delete(task));
     };
 
     invoke(`${PLUGIN}|serve`, {
@@ -252,9 +264,12 @@ class TauriAdapter extends IrohAdapter {
       console.error("[iroh-http-tauri] serve error:", err)
     );
 
+    // Resolve only after the native serve loop has stopped AND all in-flight
+    // JS handler tasks have settled (responses written), so the serve/finished
+    // contract holds the same as Node and Deno.
     return invoke<void>(`${PLUGIN}|wait_serve_stop`, {
       endpointHandle: Number(endpointHandle),
-    });
+    }).then(() => Promise.allSettled([...pending])).then(() => {});
   }
 
   closeEndpoint(handle: number, force?: boolean): Promise<void> {


### PR DESCRIPTION
## Summary

The Tauri adapter's `rawServe()` fired handler work from `channel.onmessage` but returned only `wait_serve_stop()`. The Rust dispatch callback is fire-and-forget (it sends the request event onto the channel and returns; the response is delivered later via the separate `respond_to_request` command), so `wait_serve_stop()` resolving did **not** guarantee that JS handler promises and their follow-up IPC had settled. On shutdown `rawServe()` could resolve while responses were still in flight — contradicting the serve/`finished` contract that Node and Deno uphold.

Closes #255.

## Change

Mirror the Deno adapter's drain in `packages/iroh-http-tauri/guest-js/index.ts`:

- Track each `channel.onmessage` handler task in a `pending` set, with `task.finally(() => pending.delete(task))`.
- Resolve `rawServe()` only after both `wait_serve_stop()` **and** `Promise.allSettled([...pending])` complete.
- Preserves the `u64Handle` guards added in #252 at the handler/respond sites.

## Verification

- `npm run typecheck` (Tauri package) passes.
- `deno fmt --check` clean.
- Behaviour now matches the Deno `rawServe` drain (`const pending = new Set<…>()` … `await Promise.allSettled([...pending])`).

## Notes

This is the final remaining item from the FFI runtime-safety audit. The precision-loss items shipped in #254 (#252). The audit's claimed Deno `iroh_http_start_fetch_cb` callback race was investigated and dismissed as a non-bug — the FFI symbol is blocking and the resolver is registered synchronously before the `await`, so the cross-thread callback cannot be delivered first.

A runtime integration test isn't included because the Tauri guest-js path requires a full Tauri/WebView host to exercise; the change is a structural parity fix with the Deno adapter and is covered by typecheck.