### PR TITLE
fix(deno): drain serve teardown ops so leak sanitizer stays green

### DIFF
--- a/packages/iroh-http-deno/src/adapter.ts
+++ b/packages/iroh-http-deno/src/adapter.ts
@@ -248,6 +248,13 @@ function createYieldFn(): {
 // the -1 shutdown sentinel without a timing-dependent delay.
 const serveCancellers = new Map<number, () => void>();
 
+// #245: The `stopServe` FFI call is a non-blocking op (`iroh_http_call`).
+// If it is left floating it can still be in flight when a test's `sanitizeOps`
+// snapshot is taken, which Deno's leak sanitizer reports as a leaked op. This
+// map hands the in-flight promise to the serve loop so it can drain the op
+// before resolving `finished`. Entries self-clean once the op settles.
+const serveStopOps = new Map<number, Promise<unknown>>();
+
 // ── JSON dispatch helper ──────────────────────────────────────────────────────
 
 const enc = new TextEncoder();
@@ -783,6 +790,10 @@ export const rawServe: RawServeFn = (
         } finally {
           serveCancellers.delete(endpointHandle);
           yielder.close();
+          // #245: Drain the in-flight stopServe op (if any) before resolving
+          // so no non-blocking FFI op survives past `handle.finished`.
+          const stopOp = serveStopOps.get(endpointHandle);
+          if (stopOp) await stopOp;
         }
       })();
     },
@@ -806,6 +817,11 @@ export function makeAllocBodyWriter(endpointHandle: number): AllocBodyWriterFn {
 // Sends QUIC CONNECTION_CLOSE frames so peers observe a clean disconnect.
 function _closeAllSync(): void {
   lib.symbols.iroh_http_close_all();
+  // #245: close_all removes the request queues, but a serve loop parked in
+  // `await yielder.yield()` only re-polls when its MessageChannel turn lands.
+  // Wake every loop explicitly so it sees the -1 sentinel promptly instead of
+  // relying on MessageChannel timing under load.
+  for (const cancel of serveCancellers.values()) cancel();
 }
 Deno.addSignalListener("SIGTERM", _closeAllSync);
 // SIGINT is registered only on platforms that support it (non-Windows).
@@ -909,9 +925,15 @@ export function stopServe(handle: number): void {
   // #115: Cancel the yield immediately so the polling loop re-polls and
   // sees the -1 shutdown sentinel without waiting for the MessageChannel.
   serveCancellers.get(handle)?.();
-  call<Record<never, never>>("stopServe", { endpointHandle: handle }).catch(
-    () => {},
-  );
+  // #245: Register the in-flight op so the serve loop can await it before
+  // resolving `finished`; otherwise this non-blocking FFI op can outlive the
+  // test boundary and trip Deno's `sanitizeOps` leak detector under load.
+  const op = call<Record<never, never>>("stopServe", { endpointHandle: handle })
+    .catch(() => {});
+  serveStopOps.set(handle, op);
+  void op.finally(() => {
+    if (serveStopOps.get(handle) === op) serveStopOps.delete(handle);
+  });
 }
 
 /** Resolves when the endpoint has been fully closed (explicit or native). */
@@ -1313,11 +1335,9 @@ export class DenoAdapter extends IrohAdapter {
   }
 
   stopServe(handle: number): void {
-    // #115: Cancel the yield immediately so the polling loop re-polls.
-    serveCancellers.get(handle)?.();
-    call<Record<never, never>>("stopServe", { endpointHandle: handle }).catch(
-      () => {},
-    );
+    // Delegate to the module-level stopServe so the in-flight op is tracked
+    // and drained by the serve loop (#115/#245).
+    stopServe(handle);
   }
 
   waitEndpointClosed(handle: number): Promise<void> {


### PR DESCRIPTION
Closes #245.

## Problem

The **End-to-end (Deno)** CI job intermittently failed on Deno's `sanitizeOps` leak detector during serve teardown, while every functional subtest passed (93/93). A different test tripped it each run — the signature of a teardown timing race, not a real regression. Two tests were affected: `regression #115` ("Leaks detected") and `regression #155` ("serve loop did not exit after close_all").

## Root cause

`call()` is a genuine Deno **non-blocking** async FFI op (`await lib.symbols.iroh_http_call(...)`, `nonblocking: true`) that `sanitizeOps` tracks. Two serve-teardown paths left such an op unawaited:

1. **#115** — `stopServe` fired `call("stopServe").catch(() => {})` and forgot it. On signal-abort the serve loop's `finished` could resolve before that op settled; the test's `await server.close(); await handle.finished;` never awaited it. Under CI contention the `op_ffi_call_*` op outlived the test boundary → "Leaks detected." (Locally it always won the race — 0 failures across 80 isolated, 25 full-file, and 20 under-CPU-load runs — hence CI-only.)
2. **#155** — `_closeAllSync` called `iroh_http_close_all()` but did **not** wake serve loops parked in `await yielder.yield()`. Loop exit depended entirely on MessageChannel timing rather than an explicit wake, so on a loaded runner it occasionally exceeded the test's 5 s budget.

## Approach

Both fixes are deterministic and scoped to teardown:

1. **Drain the stopServe op (#115).** Track the in-flight `stopServe` promise per endpoint in a `serveStopOps` map and `await` it in the serve loop's `finally`, before `finished` resolves — so no non-blocking FFI op can survive past `handle.finished`. The map entry self-cleans once the op settles, so it doesn't grow when no loop is running.
2. **Wake loops on close_all (#155).** `_closeAllSync` now invokes every registered `serveCanceller`, so `close_all` proactively wakes all serve loops and they see the `-1` sentinel promptly instead of waiting on a MessageChannel turn.

The object-method `stopServe` now delegates to the module-level function so both code paths get the drain behaviour. Regression tests #115 and #155 are unchanged and remain the guard.

## Verification

- `deno test -A test/adapter.test.ts`: 11/11 pass, including #115 and #155.
- Stability loop: **0/15** failures on repeated full-file runs.
- Compliance suite: **93 passed, 0 failed**.
- `deno check` + `deno fmt --check` clean.

Note: the flake is not locally reproducible even under heavy CPU load, so CI is the real proving ground — the change is justified by the op-lifecycle analysis above and leaves the existing sanitizers intact so a genuine leak would still trip them.
