### PR TITLE
chore(core): use is_some() in channel bench drain loop

### DIFF
--- a/crates/iroh-http-core/benches/channel.rs
+++ b/crates/iroh-http-core/benches/channel.rs
@@ -80,7 +80,7 @@ fn bench_handle_store_channel(c: &mut Criterion) {
                     ep.handles().finish_body(wh).unwrap();
 
                     // Drain all chunks (send_chunk splits at max_chunk_size=64KB)
-                    while let Some(_) = ep.handles().next_chunk(rh).await.unwrap() {}
+                    while ep.handles().next_chunk(rh).await.unwrap().is_some() {}
                 }
             });
         });


### PR DESCRIPTION
## Summary

One-line cleanup in `crates/iroh-http-core/benches/channel.rs`: replace `while let Some(_) = …` with `.is_some()` to satisfy clippy's `redundant_pattern_matching` lint.

```diff
- while let Some(_) = ep.handles().next_chunk(rh).await.unwrap() {}
+ while ep.handles().next_chunk(rh).await.unwrap().is_some() {}
```

## Why

Spotted while working on #205. The lint isn't gated by CI — CI runs `cargo clippy --workspace`, which excludes bench targets — so it only surfaces under `cargo clippy --all-targets`. Pure style, no behavior change.

## Verification

- `cargo clippy -p iroh-http-core --benches -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
