### PR TITLE
test(core): add coverage for untested FFI bridge modules

### DIFF
--- a/crates/iroh-http-core/src/ffi/dispatcher.rs
+++ b/crates/iroh-http-core/src/ffi/dispatcher.rs
@@ -345,3 +345,141 @@ where
 {
     ffi_serve_with_callback(endpoint, options, on_request, None)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::handles::{HandleStore, StoreConfig};
+    use crate::{NetworkingOptions, NodeOptions};
+    use http::HeaderValue;
+    use std::sync::Mutex;
+
+    // ── respond(): validation + head delivery ────────────────────────────
+
+    #[tokio::test]
+    async fn respond_rejects_invalid_status() {
+        let store = HandleStore::new(StoreConfig::default());
+        // 9999 is outside the valid 100..=999 status range.
+        let err = respond(&store, 0, 9999, vec![]).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn respond_rejects_invalid_header_name() {
+        let store = HandleStore::new(StoreConfig::default());
+        let err = respond(&store, 0, 200, vec![("bad name".into(), "v".into())]).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn respond_rejects_invalid_header_value() {
+        let store = HandleStore::new(StoreConfig::default());
+        // A newline in a header value is rejected (header injection guard).
+        let err = respond(&store, 0, 200, vec![("x".into(), "bad\nvalue".into())]).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn respond_unknown_handle_errors() {
+        let store = HandleStore::new(StoreConfig::default());
+        // Status and headers are valid, but no such request handle exists.
+        let err = respond(&store, 4242, 200, vec![("x".into(), "y".into())]).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+        assert!(err.message.contains("4242"));
+    }
+
+    #[tokio::test]
+    async fn respond_delivers_head_to_receiver() {
+        let store = HandleStore::new(StoreConfig::default());
+        let (tx, rx) = tokio::sync::oneshot::channel::<ResponseHeadEntry>();
+        let handle = store.allocate_req_handle(tx).unwrap();
+
+        respond(&store, handle, 201, vec![("x-test".into(), "yes".into())]).unwrap();
+
+        let head = rx.await.unwrap();
+        assert_eq!(head.status, 201);
+        assert_eq!(
+            head.headers,
+            vec![("x-test".to_string(), "yes".to_string())]
+        );
+        // The sender is consumed: a second respond on the same handle fails.
+        let err = respond(&store, handle, 200, vec![]).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+    }
+
+    // ── dispatch(): malformed-request rejection (ISS-011 / ISS-003) ───────
+
+    async fn local_endpoint() -> IrohEndpoint {
+        IrohEndpoint::bind(NodeOptions {
+            networking: NetworkingOptions {
+                disabled: true,
+                bind_addrs: vec!["127.0.0.1:0".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+    }
+
+    fn make_dispatcher(
+        endpoint: IrohEndpoint,
+        max_header_size: Option<usize>,
+        sink: Arc<Mutex<Vec<RequestPayload>>>,
+    ) -> Arc<FfiDispatcher> {
+        let own_node_id = Arc::new(endpoint.node_id().to_string());
+        Arc::new(FfiDispatcher {
+            on_request: Arc::new(move |p| sink.lock().unwrap().push(p)),
+            endpoint,
+            own_node_id,
+            max_header_size,
+        })
+    }
+
+    /// ISS-011: a non-UTF8 header value must be rejected with 400, not
+    /// silently coerced, and the JS callback must never fire.
+    #[tokio::test]
+    async fn dispatch_rejects_non_utf8_header_value() {
+        let endpoint = local_endpoint().await;
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let dispatcher = make_dispatcher(endpoint, None, sink.clone());
+
+        let mut req = hyper::Request::builder()
+            .method("GET")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+        req.headers_mut()
+            .insert("x-bad", HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap());
+
+        let resp = dispatcher.dispatch(req, Arc::new(String::new())).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            sink.lock().unwrap().is_empty(),
+            "callback must not fire on a rejected request",
+        );
+    }
+
+    /// ISS-003: request headers exceeding `max_header_size` are rejected with
+    /// 431 before any handle is allocated or the callback fires.
+    #[tokio::test]
+    async fn dispatch_rejects_oversized_headers() {
+        let endpoint = local_endpoint().await;
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let dispatcher = make_dispatcher(endpoint, Some(50), sink.clone());
+
+        let req = hyper::Request::builder()
+            .method("GET")
+            .uri("/")
+            .header("x-big", "a".repeat(200))
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = dispatcher.dispatch(req, Arc::new(String::new())).await;
+        assert_eq!(resp.status(), StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE);
+        assert!(
+            sink.lock().unwrap().is_empty(),
+            "callback must not fire on a rejected request",
+        );
+    }
+}

--- a/crates/iroh-http-core/src/ffi/handles.rs
+++ b/crates/iroh-http-core/src/ffi/handles.rs
@@ -1052,4 +1052,89 @@ mod tests {
         let result = recv_with_cancel(rx, cancel).await;
         assert!(result.is_none());
     }
+
+    // ── #204: concurrency, TTL sweep, and slot reuse ───────────────────
+
+    /// Many tasks inserting and freeing reader/writer handles concurrently must
+    /// not panic or leak: every slot is released by the end.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_alloc_dealloc_leaves_no_leak() {
+        let store = Arc::new(test_store());
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let s = store.clone();
+            tasks.push(tokio::spawn(async move {
+                for _ in 0..100 {
+                    let (writer, reader) = s.make_body_channel();
+                    let reader_handle = s.insert_reader(reader).unwrap();
+                    let writer_handle = s.insert_writer(writer).unwrap();
+                    s.cancel_reader(reader_handle);
+                    s.finish_body(writer_handle).unwrap();
+                }
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+
+        let (readers, writers, _sessions, total) = store.count_handles();
+        assert_eq!(readers, 0, "all reader slots should be freed");
+        assert_eq!(writers, 0, "all writer slots should be freed");
+        assert_eq!(total, 0, "no handles should leak");
+    }
+
+    /// A TTL sweep removes entries older than the TTL but keeps fresh ones, and
+    /// the swept handle becomes invalid.
+    #[tokio::test]
+    async fn sweep_removes_expired_keeps_fresh() {
+        let store = test_store();
+        // Old reader: will age past the sweep TTL.
+        let (_old_writer, old_reader) = make_body_channel();
+        let old_handle = store.insert_reader(old_reader).unwrap();
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Fresh reader: inserted right before the sweep.
+        let (_new_writer, new_reader) = make_body_channel();
+        store.insert_reader(new_reader).unwrap();
+
+        // TTL 30ms: the 60ms-old entry expires, the fresh one survives.
+        store.sweep(Duration::from_millis(30));
+
+        let (readers, _, _, _) = store.count_handles();
+        assert_eq!(readers, 1, "only the fresh reader should remain");
+        assert!(
+            store.next_chunk(old_handle).await.is_err(),
+            "the swept handle must be invalid",
+        );
+    }
+
+    /// After a handle is freed, the old handle is invalid and the underlying
+    /// slot can be reused for a new, distinct handle.
+    #[tokio::test]
+    async fn freed_handle_is_invalid_and_slot_reusable() {
+        let store = test_store();
+        let (_writer_a, reader_a) = make_body_channel();
+        let handle_a = store.insert_reader(reader_a).unwrap();
+        store.cancel_reader(handle_a); // frees the slot
+
+        assert!(
+            store.next_chunk(handle_a).await.is_err(),
+            "freed handle must be invalid",
+        );
+
+        // A new reader reuses the freed slot but gets a distinct versioned handle.
+        let (writer_b, reader_b) = store.make_body_channel();
+        let handle_b = store.insert_reader(reader_b).unwrap();
+        assert_ne!(
+            handle_a, handle_b,
+            "reused slot must yield a new versioned handle",
+        );
+
+        // The new handle is fully functional.
+        writer_b.send_chunk(Bytes::from("ok")).await.unwrap();
+        drop(writer_b);
+        assert_eq!(
+            store.next_chunk(handle_b).await.unwrap(),
+            Some(Bytes::from("ok")),
+        );
+    }
 }

--- a/crates/iroh-http-core/src/ffi/pumps.rs
+++ b/crates/iroh-http-core/src/ffi/pumps.rs
@@ -167,3 +167,160 @@ pub(crate) async fn pump_hyper_body_to_channel_limited<B>(
 
     drop(writer);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::handles::make_body_channel;
+    use super::*;
+    use http_body::Frame;
+    use http_body_util::StreamBody;
+    use std::convert::Infallible;
+    use std::time::Duration;
+    use tokio::sync::oneshot;
+
+    /// A 50-byte chunk used to exercise the byte-limit boundary.
+    const FIFTY: &[u8] = &[b'x'; 50];
+
+    /// Build a body that yields each slice as one DATA frame, then EOF.
+    fn body_from_chunks(
+        chunks: Vec<&'static [u8]>,
+    ) -> impl http_body::Body<Data = Bytes, Error = Infallible> {
+        let frames = chunks
+            .into_iter()
+            .map(|c| Ok::<_, Infallible>(Frame::data(Bytes::from_static(c))));
+        StreamBody::new(futures::stream::iter(frames))
+    }
+
+    /// Round-trip: every frame the body yields reaches the reader, in order.
+    #[tokio::test]
+    async fn pump_round_trip_forwards_all_chunks() {
+        let (writer, reader) = make_body_channel();
+        let body = body_from_chunks(vec![b"foo", b"bar", b"baz"]);
+        let pump = tokio::spawn(pump_hyper_body_to_channel_limited(
+            body,
+            writer,
+            None,
+            Duration::from_secs(5),
+            None,
+        ));
+
+        let mut collected = Vec::new();
+        while let Some(chunk) = reader.next_chunk().await {
+            collected.extend_from_slice(&chunk);
+        }
+        pump.await.unwrap();
+
+        assert_eq!(collected, b"foobarbaz");
+    }
+
+    /// Regression (hardening batch / ISS-004): a body over `max_bytes` fires the
+    /// overflow signal exactly once, forwards only the frames within the limit,
+    /// and keeps draining the rest so the pump terminates (peer not stalled).
+    #[tokio::test]
+    async fn pump_over_limit_fires_overflow_and_drains_rest() {
+        let (writer, reader) = make_body_channel();
+        let (overflow_tx, overflow_rx) = oneshot::channel();
+        // 4 × 50 = 200 bytes total, limit 100: frames 1–2 pass, 3 overflows, 4 drains.
+        let body = body_from_chunks(vec![FIFTY, FIFTY, FIFTY, FIFTY]);
+        let pump = tokio::spawn(pump_hyper_body_to_channel_limited(
+            body,
+            writer,
+            Some(100),
+            Duration::from_secs(5),
+            Some(overflow_tx),
+        ));
+
+        let mut total = 0usize;
+        while let Some(chunk) = reader.next_chunk().await {
+            total += chunk.len();
+        }
+        pump.await.unwrap();
+
+        // Only the two frames within the 100-byte limit reached the reader.
+        assert_eq!(total, 100);
+        // Overflow was signalled (sender not dropped without sending).
+        assert!(
+            overflow_rx.await.is_ok(),
+            "overflow signal should fire once"
+        );
+    }
+
+    /// Regression (hardening batch): a body that stalls mid-stream is cut off
+    /// after `frame_timeout` instead of hanging the pump forever (slowloris).
+    #[tokio::test]
+    async fn pump_breaks_when_frame_read_times_out() {
+        let (writer, reader) = make_body_channel();
+        // One frame, then the body never yields again.
+        use futures::StreamExt;
+        let frames = futures::stream::iter(vec![Ok::<_, Infallible>(Frame::data(
+            Bytes::from_static(b"first"),
+        ))])
+        .chain(futures::stream::pending());
+        let body = StreamBody::new(frames);
+
+        let start = std::time::Instant::now();
+        let pump = tokio::spawn(pump_hyper_body_to_channel_limited(
+            body,
+            writer,
+            None,
+            Duration::from_millis(50),
+            None,
+        ));
+
+        let mut collected = Vec::new();
+        while let Some(chunk) = reader.next_chunk().await {
+            collected.extend_from_slice(&chunk);
+        }
+        pump.await.unwrap();
+
+        assert_eq!(collected, b"first");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "pump should cut off the stalled body promptly",
+        );
+    }
+
+    /// Backpressure: with more frames than the channel capacity (32) and a slow
+    /// reader, every frame is still delivered without loss.
+    #[tokio::test]
+    async fn pump_delivers_all_frames_under_slow_reader() {
+        let (writer, reader) = make_body_channel();
+        let body = body_from_chunks(vec![b"x".as_slice(); 50]);
+        let pump = tokio::spawn(pump_hyper_body_to_channel_limited(
+            body,
+            writer,
+            None,
+            Duration::from_secs(5),
+            None,
+        ));
+
+        let mut count = 0usize;
+        while let Some(chunk) = reader.next_chunk().await {
+            count += chunk.len();
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        pump.await.unwrap();
+
+        assert_eq!(count, 50);
+    }
+
+    /// Cancellation: once the reader is dropped, the pump stops promptly instead
+    /// of blocking on a full channel.
+    #[tokio::test]
+    async fn pump_stops_when_reader_dropped() {
+        let (writer, reader) = make_body_channel();
+        drop(reader);
+        let body = body_from_chunks(vec![b"a", b"b", b"c"]);
+
+        let res = tokio::time::timeout(
+            Duration::from_secs(2),
+            pump_hyper_body_to_channel_limited(body, writer, None, Duration::from_secs(5), None),
+        )
+        .await;
+
+        assert!(
+            res.is_ok(),
+            "pump should terminate after the reader is dropped"
+        );
+    }
+}

--- a/crates/iroh-http-core/tests/http_accept_guards.rs
+++ b/crates/iroh-http-core/tests/http_accept_guards.rs
@@ -1,0 +1,97 @@
+#![allow(clippy::disallowed_types)] // test file — RequestPayload is valid here
+//! HTTP accept-loop guards.
+//!
+//! Regression tests for two defences in the HTTP serve loop that had no
+//! dedicated end-to-end coverage:
+//!
+//!  * `accept.rs` rejects a connection that negotiated a non-HTTP ALPN
+//!    (protocol-confusion guard), and
+//!  * `pipeline.rs` bounds the request-head read so a peer cannot hold a
+//!    bistream open by withholding header bytes (slowloris guard).
+
+mod common;
+
+use std::time::Duration;
+
+use iroh_http_core::{ffi_serve, IrohEndpoint, RequestPayload, ServeOptions, ALPN, ALPN_DUPLEX};
+
+/// Build an `EndpointAddr` for the server from its public key + direct addrs.
+fn server_addr(server_ep: &IrohEndpoint) -> iroh::EndpointAddr {
+    let mut addr = iroh::EndpointAddr::new(server_ep.raw().id());
+    for a in common::server_addrs(server_ep) {
+        addr = addr.with_ip_addr(a);
+    }
+    addr
+}
+
+/// The HTTP serve loop must reject a connection that negotiated the duplex
+/// session ALPN instead of the HTTP ALPN — handing it to the HTTP service
+/// would be protocol confusion.
+#[tokio::test]
+async fn serve_loop_rejects_non_http_alpn() {
+    let (server_ep, client_ep) = common::make_pair().await;
+    let addr = server_addr(&server_ep);
+
+    let _serve = ffi_serve(
+        server_ep.clone(),
+        ServeOptions::default(),
+        |_p: RequestPayload| {},
+    );
+
+    // Connect with the duplex ALPN (advertised by the server), not HTTP.
+    let conn = client_ep
+        .raw()
+        .connect(addr, ALPN_DUPLEX)
+        .await
+        .expect("duplex ALPN negotiates — the server advertises it");
+    assert_eq!(conn.alpn(), ALPN_DUPLEX);
+
+    // The HTTP accept loop must close it promptly with "unexpected ALPN".
+    let err = tokio::time::timeout(Duration::from_secs(5), conn.closed())
+        .await
+        .expect("server should close the non-HTTP connection, not hang");
+    match err {
+        iroh::endpoint::ConnectionError::ApplicationClosed(info) => {
+            assert_eq!(&info.reason[..], b"unexpected ALPN");
+        }
+        other => panic!("expected an application close, got: {other:?}"),
+    }
+}
+
+/// A peer that opens a bistream but never sends a complete request head must
+/// be timed out: the server closes the stream rather than waiting forever.
+#[tokio::test]
+async fn serve_loop_times_out_slow_request_head() {
+    let (server_ep, client_ep) = common::make_pair().await;
+    let addr = server_addr(&server_ep);
+
+    // Short head-read budget (reuses the request timeout).
+    let opts = ServeOptions {
+        request_timeout_ms: Some(200),
+        ..Default::default()
+    };
+    let _serve = ffi_serve(server_ep.clone(), opts, |_p: RequestPayload| {});
+
+    let conn = client_ep
+        .raw()
+        .connect(addr, ALPN)
+        .await
+        .expect("HTTP ALPN negotiates");
+    let (mut send, mut recv) = conn.open_bi().await.expect("open bistream");
+
+    // Send a partial request head and stop: the server's accept_bi yields (so
+    // hyper begins reading the head) but the head never terminates. Without
+    // the head-read timeout the server would block forever and this read would
+    // hang past the outer budget; with it, the server resets/closes the stream
+    // and the read resolves well within the window. `send` is kept alive so
+    // the stream stays open (no finish/reset from our side).
+    send.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n")
+        .await
+        .expect("write partial head");
+    let read = tokio::time::timeout(Duration::from_secs(5), recv.read_to_end(1024)).await;
+    assert!(
+        read.is_ok(),
+        "server must time out a slow request head instead of hanging",
+    );
+    drop(send);
+}

--- a/crates/iroh-http-core/tests/session_alpn.rs
+++ b/crates/iroh-http-core/tests/session_alpn.rs
@@ -6,7 +6,7 @@
 //! bidirectional session. This is a regression guard for the ALPN check in
 //! `ffi::session::Session::accept`.
 
-use iroh_http_core::{IrohEndpoint, NetworkingOptions, NodeOptions, Session, ALPN};
+use iroh_http_core::{ErrorCode, IrohEndpoint, NetworkingOptions, NodeOptions, Session, ALPN};
 
 /// Two locally-connected endpoints (relay disabled, loopback only). Both
 /// advertise the duplex and plain-HTTP ALPNs by default.
@@ -52,6 +52,8 @@ async fn accept_rejects_non_duplex_alpn() {
         .unwrap()
         .err()
         .expect("accept must reject a non-duplex ALPN");
+    // Assert the machine-readable code first; the message is an extra guard.
+    assert_eq!(err.code, ErrorCode::ConnectionFailed);
     assert!(
         err.message.contains("unexpected ALPN"),
         "unexpected error: {}",

--- a/crates/iroh-http-core/tests/session_alpn.rs
+++ b/crates/iroh-http-core/tests/session_alpn.rs
@@ -1,0 +1,63 @@
+//! Session ALPN enforcement.
+//!
+//! [`Session::accept`] must reject connections that negotiated a non-duplex
+//! ALPN (e.g. plain HTTP). Surfacing such a connection as a raw session would
+//! be protocol confusion: a peer that handshook for HTTP must not be handed a
+//! bidirectional session. This is a regression guard for the ALPN check in
+//! `ffi::session::Session::accept`.
+
+use iroh_http_core::{IrohEndpoint, NetworkingOptions, NodeOptions, Session, ALPN};
+
+/// Two locally-connected endpoints (relay disabled, loopback only). Both
+/// advertise the duplex and plain-HTTP ALPNs by default.
+async fn make_pair() -> (IrohEndpoint, IrohEndpoint) {
+    let opts = || NodeOptions {
+        networking: NetworkingOptions {
+            disabled: true,
+            bind_addrs: vec!["127.0.0.1:0".into()],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let a = IrohEndpoint::bind(opts()).await.unwrap();
+    let b = IrohEndpoint::bind(opts()).await.unwrap();
+    (a, b)
+}
+
+#[tokio::test]
+async fn accept_rejects_non_duplex_alpn() {
+    let (client_ep, server_ep) = make_pair().await;
+
+    let server_pk = server_ep.raw().id();
+    let addrs: Vec<std::net::SocketAddr> = server_ep.raw().addr().ip_addrs().cloned().collect();
+    let mut addr = iroh::EndpointAddr::new(server_pk);
+    for a in &addrs {
+        addr = addr.with_ip_addr(*a);
+    }
+
+    // Server accepts the next incoming connection and must reject it.
+    let server_handle = tokio::spawn(async move { Session::accept(server_ep).await });
+
+    // Client connects with the plain HTTP ALPN (advertised by the server),
+    // NOT the duplex session ALPN.
+    let conn = client_ep
+        .raw()
+        .connect(addr, ALPN)
+        .await
+        .expect("handshake negotiates the HTTP ALPN");
+    assert_eq!(conn.alpn(), ALPN, "client negotiated the HTTP ALPN");
+
+    let err = server_handle
+        .await
+        .unwrap()
+        .err()
+        .expect("accept must reject a non-duplex ALPN");
+    assert!(
+        err.message.contains("unexpected ALPN"),
+        "unexpected error: {}",
+        err.message,
+    );
+
+    // Hold the client connection until after the assertions.
+    drop(conn);
+}

--- a/crates/iroh-http-core/tests/session_webtransport.rs
+++ b/crates/iroh-http-core/tests/session_webtransport.rs
@@ -189,3 +189,35 @@ async fn session_close_with_code_and_reason() {
     assert_eq!(info.close_code, 42);
     assert_eq!(info.reason, "done");
 }
+
+// -- Idempotent close ---------------------------------------------------------
+
+#[tokio::test]
+async fn session_double_close_is_idempotent() {
+    let (a_ep, b_ep) = make_pair().await;
+    let b_id = node_id(&b_ep);
+    let b_addrs = direct_addrs(&b_ep);
+
+    let b_ep_spawn = b_ep.clone();
+    let b_handle = tokio::spawn(async move {
+        let session_b = Session::accept(b_ep_spawn).await.unwrap().unwrap();
+        session_b.closed().await.unwrap();
+    });
+
+    let session_a = Session::connect(a_ep.clone(), &b_id, Some(&b_addrs))
+        .await
+        .unwrap();
+
+    // Closing twice must not error — the second close is a no-op.
+    session_a.close(0, "first").unwrap();
+    session_a.close(0, "second").unwrap();
+
+    // closed() is also idempotent: the first call removes the registry entry,
+    // the second returns a default CloseInfo instead of erroring.
+    let _first = session_a.closed().await.unwrap();
+    let second = session_a.closed().await.unwrap();
+    assert_eq!(second.close_code, 0);
+    assert_eq!(second.reason, "");
+
+    b_handle.await.unwrap();
+}

--- a/crates/iroh-http-core/tests/session_webtransport.rs
+++ b/crates/iroh-http-core/tests/session_webtransport.rs
@@ -208,7 +208,7 @@ async fn session_double_close_is_idempotent() {
         .await
         .unwrap();
 
-    // Closing twice must not error — the second close is a no-op.
+    // Closing twice must not error — `close` is safe to call repeatedly.
     session_a.close(0, "first").unwrap();
     session_a.close(0, "second").unwrap();
 


### PR DESCRIPTION
## Summary

Adds unit and integration test coverage for the previously-untested FFI
bridge modules called out in #204, plus regression guards for the security
hardening merged in #260.

Closes #204.

## What's covered

**`ffi::pumps`** (unit) — body pump helpers
- round-trip forwarding, byte-limit overflow fires + drains the rest (⭐ ISS-004),
  per-frame read timeout (⭐ slowloris), slow-reader backpressure, reader-drop cancellation.

**`ffi::handles`** (unit) — handle store
- concurrent alloc/dealloc leaves no leak, selective TTL sweep (expired removed /
  fresh kept / swept handle invalid), slot reuse yields a distinct versioned handle.
- (max-handles cap was already covered by `capacity_cap_rejects_overflow`.)

**`ffi::dispatcher`** (unit) — JS-callback bridge
- `respond()` validation (invalid status, header name, header value, unknown
  handle) and head delivery to the waiting receiver.
- `dispatch()` rejects a non-UTF8 header value with 400 (⭐ ISS-011) and oversized
  headers with 431 (⭐ ISS-003), verifying the JS callback never fires on rejection.

**`ffi::session`** (integration) — QUIC session
- `Session::accept` rejects a connection negotiated with the plain-HTTP ALPN
  instead of the duplex ALPN (⭐ protocol-confusion guard).
- `close()` / `closed()` are idempotent.

**HTTP accept loop** (integration) — `http::server::{accept, pipeline}`
- the serve loop rejects a connection negotiated with the duplex (non-HTTP) ALPN (⭐),
- the head-read timeout closes a bistream whose request head is withheld (⭐ slowloris).

## Notes / scope deltas vs the original issue

- The issue's claim that `ffi::fetch` has no test functions is **stale** — it
  already has tests, so it was not re-covered here.
- Scope was expanded (per a secondary review) to add four hardening regressions
  marked ⭐ above, since the #260 batch shipped without dedicated coverage.

## Verification

`cargo test -p iroh-http-core` — all green.
`cargo fmt -p iroh-http-core` + `cargo clippy -p iroh-http-core --tests -- -D warnings` — clean.