### PR TITLE
docs: replace nonexistent maxRequestBodyBytes with real wire/decoded caps

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,7 +188,8 @@ Handles cross FFI as `u64`. In JavaScript: transmitted as `BigInt`, converted at
 | Per-request timeout | 60 000 ms | `ServeOptions::request_timeout_ms` |
 | Per-peer connection limit | 8 | `ServeOptions::max_connections_per_peer` |
 | Max request head size | 64 KB | `NodeOptions::max_header_size` |
-| Max request body size | none | `ServeOptions::max_request_body_bytes` |
+| Max request body size (wire) | 16 MiB | `ServeOptions::max_request_body_wire_bytes` |
+| Max request body size (decoded) | 16 MiB | `ServeOptions::max_request_body_decoded_bytes` |
 | Drain timeout | 30 000 ms | `ServeOptions::drain_timeout_ms` |
 
 All defaults are safe against hostile peers without opt-in. Increasing limits is always explicit.

--- a/docs/features/server-limits.md
+++ b/docs/features/server-limits.md
@@ -17,9 +17,13 @@ node.serve({
   /** Per-request timeout in milliseconds. Default: 60 000. */
   requestTimeout: 60_000,
 
-  /** Maximum request body size in bytes. Requests with larger bodies are
-   *  rejected with 413 before the body is read. Default: 16 MiB. */
-  maxRequestBodyBytes: 10 * 1024 * 1024,  // 10 MB example
+  /** Maximum request body size in **wire** (compressed) bytes. Requests with
+   *  larger bodies are rejected with 413 before the body is read. Default: 16 MiB. */
+  maxRequestBodyWireBytes: 10 * 1024 * 1024,  // 10 MB example
+
+  /** Maximum request body size in **decoded** bytes (after decompression).
+   *  Primary compression-bomb guard. Default: 16 MiB. */
+  maxRequestBodyDecodedBytes: 10 * 1024 * 1024,  // 10 MB example
 
   /** Maximum consecutive accept-loop errors before shutdown. Default: 5. */
   maxServeErrors: 5,
@@ -45,10 +49,28 @@ These limits intercept bytes or connections before they reach the FFI
 boundary. A JS handler never runs for a rejected request, so no user code
 needs to handle the overflow cases.
 
-For example, without `maxRequestBodyBytes` a peer could stream an unbounded
+For example, without `maxRequestBodyWireBytes` a peer could stream an unbounded
 body, accumulating data in the channel until memory is exhausted. The limit
 is checked as bytes arrive in the Rust body reader — no full-body buffering
 occurs.
+
+## Wire bytes vs decoded bytes
+
+Request body size is capped at two distinct points, and both default to 16 MiB:
+
+- **`maxRequestBodyWireBytes`** limits the **compressed** bytes as they arrive
+  off the network. It guards against high-bandwidth floods at the transport
+  level, before any decompression work is done.
+- **`maxRequestBodyDecodedBytes`** limits the **decoded** bytes *after*
+  decompression. This is the primary compression-bomb guard: a payload that is
+  tiny on the wire (e.g. a zstd stream) but expands to gigabytes is rejected
+  here.
+
+Both are enforced incrementally as bytes flow, so an oversized body is rejected
+with `413 Content Too Large` without ever being fully buffered. When
+`decompress` is `false`, bodies are not decoded and only the wire limit applies.
+
+There is **no** single `maxRequestBodyBytes` option — use the two caps above.
 
 ## What each limit protects against
 
@@ -57,6 +79,7 @@ occurs.
 | `maxConcurrency` | Request flood from many peers | Excess requests queue until a slot is free; if none frees before `requestTimeout`, they receive a `408 Request Timeout` |
 | `maxConnectionsPerPeer` | Connection flood from one peer | Excess connections are closed at the QUIC level (transport close, not an HTTP response) |
 | `requestTimeout` | Slow request / stalled handler | 408 Request Timeout |
-| `maxRequestBodyBytes` | Oversized body exhausting memory | 413 Content Too Large |
+| `maxRequestBodyWireBytes` | Oversized compressed body exhausting bandwidth/memory | 413 Content Too Large |
+| `maxRequestBodyDecodedBytes` | Compression bomb expanding after decode | 413 Content Too Large |
 | `maxHeaderBytes` | Header flood exhausting memory | 431 Request Header Fields Too Large |
 

--- a/docs/internals/http-engine.md
+++ b/docs/internals/http-engine.md
@@ -126,7 +126,8 @@ Duplex mode uses HTTP Upgrade semantics. The ALPN for duplex connections is `iro
 | Limit | Configured via | Enforcement |
 |-------|---------------|-------------|
 | Max header size | `NodeOptions::max_header_size` (default 64 KB) | `max_buf_size(limit.max(8192))` on hyper builder + post-parse byte-count check |
-| Max request body | `ServeOptions::max_request_body_bytes` | Byte counter in `pump_hyper_body_to_channel_limited` |
+| Max request body (wire) | `ServeOptions::max_request_body_wire_bytes` | Byte counter in `pump_hyper_body_to_channel_limited` (counts compressed bytes) |
+| Max request body (decoded) | `ServeOptions::max_request_body_decoded_bytes` | Byte counter after decompression (compression-bomb guard) |
 | Max concurrent requests | `ServeOptions::max_concurrency` (default 64) | Drain semaphore: one permit per in-flight bi-stream |
 | Per-request timeout | `ServeOptions::request_timeout_ms` (default 60 s) | `TimeoutService` wrapping `RequestService` |
 | Max connections per peer | `ServeOptions::max_connections_per_peer` (default 8) | `PeerConnectionGuard` + `DashMap` counter |

--- a/docs/recipes/schema-negotiation.md
+++ b/docs/recipes/schema-negotiation.md
@@ -37,7 +37,8 @@ Every node publishes a machine-readable API description:
 interface ApiCapabilities {
   versions: string[];                    // semver strings, oldest first
   extensions?: string[];                 // named optional features
-  maxRequestBodyBytes?: number;
+  maxRequestBodyWireBytes?: number;
+  maxRequestBodyDecodedBytes?: number;
   supportsCompression?: boolean;
   supportsStreaming?: boolean;
   supportsWebTransport?: boolean;

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -225,8 +225,10 @@ interface ServeOptions {
   maxConnectionsPerPeer?: number;
   /** Per-request timeout in ms. Default: 60 000. 0 = disabled. */
   requestTimeout?: number;
-  /** Max request body size in bytes. Default: 16 777 216 (16 MiB). */
-  maxRequestBodyBytes?: number;
+  /** Max request body size in wire (compressed) bytes. Default: 16 777 216 (16 MiB). */
+  maxRequestBodyWireBytes?: number;
+  /** Max request body size in decoded (post-decompression) bytes. Default: 16 777 216 (16 MiB). */
+  maxRequestBodyDecodedBytes?: number;
   /** Max total QUIC connections. Unlimited by default. */
   maxTotalConnections?: number;
   /** Max consecutive accept errors before shutdown. Default: 5. */
@@ -778,8 +780,12 @@ Configured via `NodeOptions` or `ServeOptions`. See [server-limits.md](features/
 | `maxConcurrency` | Request flood | 408 Request Timeout |
 | `maxConnectionsPerPeer` | Connection flood | Closed at QUIC level |
 | `requestTimeout` | Slow request | 408 Request Timeout |
-| `maxRequestBodyBytes` | Oversized body | 413 Content Too Large |
+| `maxRequestBodyWireBytes` | Oversized compressed body | 413 Content Too Large |
+| `maxRequestBodyDecodedBytes` | Compression bomb (post-decode) | 413 Content Too Large |
 | `maxHeaderBytes` | Header flood | 431 Request Header Fields Too Large |
+
+See [wire bytes vs decoded bytes](features/server-limits.md#wire-bytes-vs-decoded-bytes)
+for how the two request-body caps differ.
 
 ### WebTransport
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -78,7 +78,8 @@ configurable via `NodeOptions`):
 
 | Limit | Default | Protects against |
 |---|---|---|
-| `maxRequestBodyBytes` | 16 MiB | Request body exhausting memory |
+| `maxRequestBodyWireBytes` | 16 MiB | Compressed request body exhausting bandwidth/memory |
+| `maxRequestBodyDecodedBytes` | 16 MiB | Compression bomb exhausting memory after decode |
 | `maxConcurrency` | 1 024 | Request flood from many peers |
 | `maxConnectionsPerPeer` | 8 | Connection flood from one peer |
 | `requestTimeout` | 60 s | Slow request / stalled handler |
@@ -86,6 +87,9 @@ configurable via `NodeOptions`):
 | `maxTotalConnections` | unlimited | Total QUIC connection cap |
 | QUIC `max_concurrent_bidi_streams` | 128 | Stream-level slowloris |
 | Response body limit | 256 MiB | Compression bomb from malicious server |
+
+The distinction between the wire and decoded body caps is explained in
+[wire bytes vs decoded bytes](features/server-limits.md#wire-bytes-vs-decoded-bytes).
 
 ## Out-of-scope threats
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -145,7 +145,7 @@ mDNS uses UDP multicast on port 5353. Common blockers:
 | `InvalidInput` | `IrohArgumentError` | Bad node ID, invalid URL scheme, invalid header | Check input format; URLs must use `httpi://` scheme |
 | `ConnectionFailed` | `IrohConnectError` | No network path, peer offline | See [connection errors](#networkerror-on-fetch--connection-refused-or-connection-failed) |
 | `Timeout` | `IrohConnectError` | Peer too slow, network timeout | Increase `requestTimeout`; retry with backoff |
-| `BodyTooLarge` | `IrohProtocolError` | Request body exceeds `maxRequestBodyBytes` | Send smaller payload or increase limit |
+| `BodyTooLarge` | `IrohProtocolError` | Request body exceeds `maxRequestBodyWireBytes` or `maxRequestBodyDecodedBytes` | Send smaller payload or increase the relevant limit |
 | `HeaderTooLarge` | `IrohProtocolError` | Header block exceeds `maxHeaderBytes` | Reduce header count/size or increase limit |
 | `PeerRejected` | `IrohConnectError` | Peer rejected connection at app layer | See [peer rejected](#networkerror--peer-rejected) |
 | `Cancelled` | `IrohAbortError` | `AbortSignal` fired or `fetch()` cancelled | Handle `AbortError` in caller; do not retry cancelled requests |

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -154,9 +154,13 @@ cannot distinguish a migrating connection from a dead one. Lower
 | `requestTimeout` | 60 000 ms | Transfers large files (increase) or want fast failure detection (decrease) |
 | `maxConcurrency` | 1 024 | Serving many concurrent requests (increase); or throttling (decrease) |
 | `maxConnectionsPerPeer` | 8 | IoT with few connections/peer (decrease); busy API clients (increase) |
-| `maxRequestBodyBytes` | unlimited | Prevent large upload attacks (set a limit) |
+| `maxRequestBodyWireBytes` | 16 MiB | Prevent large upload floods (compressed wire bytes) |
+| `maxRequestBodyDecodedBytes` | 16 MiB | Prevent compression bombs (post-decompression bytes) |
 | `drainTimeout` | 5 000 ms | Slow readers expected (increase); tight latency SLA (decrease) |
 | `maxServeErrors` | 5 | Noisy channels (increase); fail-fast desired (decrease) |
+
+> The two request-body caps guard different layers — see
+> [wire bytes vs decoded bytes](features/server-limits.md#wire-bytes-vs-decoded-bytes).
 
 ---
 


### PR DESCRIPTION
## Summary

Multiple docs instructed users to set `maxRequestBodyBytes` (Rust `max_request_body_bytes`) as a request-body security cap. **No runtime implements this option** — the unknown key is silently ignored, so following the docs gave a false sense of protection.

The real options (defined in `packages/iroh-http-shared/src/serve.ts`, Rust `crates/iroh-http-core/src/http/server/stack.rs`) are:

- **`maxRequestBodyWireBytes`** / `max_request_body_wire_bytes` — caps compressed **wire** bytes as they arrive (bandwidth-flood guard).
- **`maxRequestBodyDecodedBytes`** / `max_request_body_decoded_bytes` — caps **decoded** bytes after decompression (primary compression-bomb guard).

## Changes

- Replaced every `maxRequestBodyBytes` / `max_request_body_bytes` reference across the docs with the correct wire/decoded options:
  - `docs/specification.md`, `docs/tuning.md`, `docs/threat-model.md`, `docs/troubleshooting.md`, `docs/features/server-limits.md`, `docs/recipes/schema-negotiation.md`, `docs/architecture.md`, `docs/internals/http-engine.md`.
- Added a canonical **"Wire bytes vs decoded bytes"** section in `docs/features/server-limits.md` explaining the distinction once, and linked the other docs to it.

## Acceptance

- No doc references `maxRequestBodyBytes` / `max_request_body_bytes` as a settable option (the only remaining mention explicitly states the option does **not** exist).
- The wire-vs-decoded distinction is explained in one canonical place.
- Docs-only change; outside all `npm run ci` scopes (`deno fmt` covers `packages`/`examples`/`tests`, and there are no doc tests/link-checkers). `npm run fmt:check` passes.

Closes #270