### PR TITLE
docs: fix contradictory maxConcurrency default (64 → 1024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The server stack is composed from [tower-http](https://docs.rs/tower-http) layer
 |---------|-----|---------|
 | **Compression** | zstd via tower-http (request decompression + response compression) | Level 3, bodies > 1 KiB |
 | **Timeouts** | Per-request timeout layer | 60 s |
-| **Concurrency** | Semaphore-gated request limit | 64 concurrent |
+| **Concurrency** | Semaphore-gated request limit | 1024 concurrent |
 | **Load shedding** | 503 when overloaded | Automatic |
 | **Connection pool** | moka cache with single-flight connect | Per-peer reuse |
 | **Per-peer limits** | Max connections per remote node | 8 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ Handles cross FFI as `u64`. In JavaScript: transmitted as `BigInt`, converted at
 
 | Limit | Default | Config |
 |-------|---------|--------|
-| Max concurrent requests | 64 | `ServeOptions::max_concurrency` |
+| Max concurrent requests | 1024 | `ServeOptions::max_concurrency` |
 | Per-request timeout | 60 000 ms | `ServeOptions::request_timeout_ms` |
 | Per-peer connection limit | 8 | `ServeOptions::max_connections_per_peer` |
 | Max request head size | 64 KB | `NodeOptions::max_header_size` |
@@ -192,6 +192,8 @@ Handles cross FFI as `u64`. In JavaScript: transmitted as `BigInt`, converted at
 | Drain timeout | 30 000 ms | `ServeOptions::drain_timeout_ms` |
 
 All defaults are safe against hostile peers without opt-in. Increasing limits is always explicit.
+
+> **Source of truth:** these defaults are defined in `crates/iroh-http-core/src/http/server/options.rs` (e.g. `DEFAULT_CONCURRENCY = 1024`). Docs should mirror those constants — if they ever disagree, the code wins.
 
 ---
 

--- a/docs/internals/http-engine.md
+++ b/docs/internals/http-engine.md
@@ -127,7 +127,7 @@ Duplex mode uses HTTP Upgrade semantics. The ALPN for duplex connections is `iro
 |-------|---------------|-------------|
 | Max header size | `NodeOptions::max_header_size` (default 64 KB) | `max_buf_size(limit.max(8192))` on hyper builder + post-parse byte-count check |
 | Max request body | `ServeOptions::max_request_body_bytes` | Byte counter in `pump_hyper_body_to_channel_limited` |
-| Max concurrent requests | `ServeOptions::max_concurrency` (default 64) | Drain semaphore: one permit per in-flight bi-stream |
+| Max concurrent requests | `ServeOptions::max_concurrency` (default 1024) | Drain semaphore: one permit per in-flight bi-stream |
 | Per-request timeout | `ServeOptions::request_timeout_ms` (default 60 s) | `TimeoutService` wrapping `RequestService` |
 | Max connections per peer | `ServeOptions::max_connections_per_peer` (default 8) | `PeerConnectionGuard` + `DashMap` counter |
 


### PR DESCRIPTION
## Summary

The documented `ServeOptions.maxConcurrency` default contradicted itself across the docs. The true runtime default is **1024** (`DEFAULT_CONCURRENCY` in `crates/iroh-http-core/src/http/server/options.rs`), but several places still stated 64.

## Changes
- **README.md** (L52): `Semaphore-gated request limit` 64 → **1024 concurrent**
- **docs/architecture.md** (Security Defaults table): `Max concurrent requests` 64 → **1024**, and added a single **source-of-truth note** pointing at `DEFAULT_CONCURRENCY = 1024`
- **docs/internals/http-engine.md** (L130): `max_concurrency (default 64)` → **(default 1024)** — an additional straggler found via repo-wide grep

Verified via `grep` that no other `maxConcurrency`-related `64` references remain (CHANGELOG entries are historical and left intact). Already-correct references (docs/specification.md, docs/tuning.md, docs/threat-model.md, docs/troubleshooting.md, docs/features/server-limits.md, node/deno type defs) were confirmed consistent.

## Verification
Ran `npm run ci`: fmt ✓, lint ✓, all Rust tests ✓, Tauri tests ✓, guest-js tests ✓. The only failing step is `cargo-deny` **advisories**, which flags a pre-existing upstream `quick-xml` RUSTSEC advisory in a transitive dependency of `iroh` — unrelated to this docs-only change.

Closes #276