### PR TITLE
ci: add non-blocking cargo-llvm-cov coverage job (#206)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,102 @@
+name: Coverage
+
+# Non-blocking code coverage for the Rust workspace (primarily iroh-http-core),
+# measured with cargo-llvm-cov. Phase 1: this is a baseline report only — it is a
+# standalone workflow (not part of the required `CI` checks) and every coverage
+# step is `continue-on-error: true`, so it can never fail a pull request or block
+# a merge. The report is printed to the job summary and uploaded as a workflow
+# artifact (lcov + text summary). No third-party upload integrations or secrets.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/skills/**'
+      - '.vscode/**'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'LICENSE*'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/skills/**'
+      - '.vscode/**'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'LICENSE*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  # ── Baseline Rust coverage — non-blocking (never a required check) ────────────
+  coverage:
+    name: Rust coverage (llvm-cov)
+    runs-on: ubuntu-latest
+    # Belt-and-braces: even if a coverage step errors, the job is reported as a
+    # success so it never gates a PR while we establish a baseline in phase 1.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: cargo llvm-cov (lcov + summary)
+        continue-on-error: true
+        run: |
+          # Generate an lcov report for external tooling and a human-readable
+          # summary for the job log. Scoped to the workspace crates
+          # (iroh-http-core, iroh-http-discovery, …); the Tauri crate keeps its
+          # own out-of-workspace Cargo.lock and is not included here.
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov --workspace --summary-only | tee coverage-summary.txt
+
+      - name: Publish coverage summary to job summary
+        if: always()
+        continue-on-error: true
+        run: |
+          {
+            echo '## Rust coverage (cargo-llvm-cov)'
+            echo ''
+            echo 'Non-blocking baseline report — see the `coverage-report` artifact for the full lcov data.'
+            echo ''
+            echo '```'
+            cat coverage-summary.txt 2>/dev/null || echo 'No coverage summary was produced.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            lcov.info
+            coverage-summary.txt
+          retention-days: 30
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # iroh-http
 
 [![CI](https://github.com/momics/iroh-http/actions/workflows/ci.yml/badge.svg)](https://github.com/momics/iroh-http/actions/workflows/ci.yml)
+[![Coverage](https://github.com/momics/iroh-http/actions/workflows/coverage.yml/badge.svg)](https://github.com/momics/iroh-http/actions/workflows/coverage.yml)
 [![npm](https://img.shields.io/npm/v/@momics/iroh-http-node)](https://www.npmjs.com/package/@momics/iroh-http-node)
 [![JSR](https://jsr.io/badges/@momics/iroh-http-deno)](https://jsr.io/@momics/iroh-http-deno)
 [![crates.io](https://img.shields.io/crates/v/iroh-http-core)](https://crates.io/crates/iroh-http-core)
@@ -127,6 +128,14 @@ Per-target:
 ```sh
 npm run build:core    npm run build:node    npm run build:deno    npm run build:tauri
 npm run test:rust     npm run test:node     npm run test:deno     npm run test:interop
+```
+
+### Coverage
+
+The [Coverage workflow](.github/workflows/coverage.yml) runs [`cargo llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) over the Rust workspace on every push and PR. It is **non-blocking** — a baseline report only, never a required check — and publishes an lcov + text summary to the job summary and a `coverage-report` artifact. Reproduce locally with:
+```sh
+cargo install cargo-llvm-cov
+cargo llvm-cov --workspace --summary-only
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
## Summary

Adds a baseline **code coverage** measurement for the Rust workspace using [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov), implementing **Phase 1** of #206. Previously the project had no coverage tooling at all (no tarpaulin/llvm-cov/grcov, no reports, no badge).

## What the job does

A new standalone `Coverage` workflow (`.github/workflows/coverage.yml`) with a single `coverage` job that:

- Installs `cargo-llvm-cov` via `taiki-e/install-action@v2` (consistent with how `cargo-audit` is installed in `ci.yml`) and adds the `llvm-tools-preview` component.
- Uses the same toolchain conventions as the rest of CI: `actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`.
- Runs `cargo llvm-cov --workspace` to produce **both** an `lcov.info` report (for external tooling) and a human-readable `--summary-only` text report.
- Publishes the summary to the **job summary** (`$GITHUB_STEP_SUMMARY`) and uploads `lcov.info` + `coverage-summary.txt` as the `coverage-report` artifact (30-day retention).
- No third-party upload integrations (no Codecov) and **no secrets** — artifact + log summary only, per the phase-1 guardrail.

Scope note: `--workspace` covers `iroh-http-core`, `iroh-http-discovery`, and the JS adapters' Rust crates. The Tauri crate keeps its own out-of-workspace `Cargo.lock` and is intentionally excluded.

## Non-blocking rationale

This must never gate merges in phase 1, enforced two ways:

1. It is a **separate workflow**, not part of the required `CI` checks — so it is not a required status check.
2. The job sets `continue-on-error: true`, and every coverage/publish/upload step is also `continue-on-error: true` (with `if: always()` on reporting/upload) — so even a coverage failure reports the job as successful and cannot block a PR.

## README

Added a tokenless GitHub Actions **workflow-status badge** (no external service/secret) and a short "Coverage" note under Development explaining the non-blocking job and how to reproduce locally.

## Verification

- `coverage.yml` validated with `@action-validator/cli` and a YAML parse — well-formed.
- Changes are limited to `.github/workflows/coverage.yml` and `README.md`; no Rust source, tests, `Cargo.toml`/`Cargo.lock`, adapters, or other docs touched. Existing `Verify` and `version-bump-policy` jobs are untouched. No version-field bumps.

Closes #206