### PR TITLE
fix(core): reuse watcher on repeated subscribe_path_changes (#298)

### DIFF
--- a/crates/iroh-http-core/src/endpoint/observe.rs
+++ b/crates/iroh-http-core/src/endpoint/observe.rs
@@ -163,16 +163,30 @@ impl IrohEndpoint {
     /// Spawns a background watcher task the first time a given peer is subscribed.
     /// The watcher polls `peer_stats()` every 200 ms and emits on the returned
     /// channel whenever the active path changes.
+    ///
+    /// Re-subscribing to a peer that already has a live watcher reuses that
+    /// watcher: only the sender is swapped, so no additional task is spawned and
+    /// `active_path_watchers` still counts exactly one live watcher per peer.
     pub fn subscribe_path_changes(
         &self,
         node_id_str: &str,
     ) -> tokio::sync::mpsc::UnboundedReceiver<PathInfo> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        // Replace any existing sender; old watcher exits when it detects is_closed().
-        self.inner
+        // Replace any existing sender; the running watcher (if any) picks up the
+        // new sender on its next poll. `insert` returns the previous sender when
+        // a watcher is already live for this peer.
+        let had_existing_watcher = self
+            .inner
             .session
             .path_subs
-            .insert(node_id_str.to_string(), tx);
+            .insert(node_id_str.to_string(), tx)
+            .is_some();
+
+        // A watcher already exists for this peer — reuse it. Spawning another
+        // would leak a task and over-count `active_path_watchers`.
+        if had_existing_watcher {
+            return rx;
+        }
 
         let ep = self.clone();
         let nid = node_id_str.to_string();

--- a/crates/iroh-http-core/tests/observe.rs
+++ b/crates/iroh-http-core/tests/observe.rs
@@ -1,0 +1,85 @@
+//! Regression tests for peer path-change observation (`subscribe_path_changes`).
+
+use std::time::Duration;
+
+use iroh_http_core::{IrohEndpoint, NetworkingOptions, NodeOptions};
+
+async fn bind_disabled() -> IrohEndpoint {
+    IrohEndpoint::bind(NodeOptions {
+        networking: NetworkingOptions {
+            disabled: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .await
+    .unwrap()
+}
+
+/// Regression: #298 — repeated `subscribe_path_changes` for the SAME peer leaks
+/// a watcher task each call and over-counts `active_path_watchers`.
+///
+/// Root cause: each call unconditionally spawned a new watcher task and did
+/// `active_path_watchers.fetch_add(1, …)`. Replacing the sender in `path_subs`
+/// did not stop the previous watcher (it re-read the map key and saw the new,
+/// non-closed sender), so old watchers never exited.
+///
+/// Fix: reuse the existing watcher for a peer that is already subscribed —
+/// replace only the sender, and neither spawn a new task nor bump the gauge.
+#[tokio::test]
+async fn repeated_subscribe_same_peer_counts_one_watcher() {
+    let ep = bind_disabled().await;
+    let peer = "test-peer-node-id";
+
+    // Subscribe three times for the same peer. Hold every receiver alive so
+    // none of the senders report `is_closed()`.
+    let _rx1 = ep.subscribe_path_changes(peer);
+    let _rx2 = ep.subscribe_path_changes(peer);
+    let _rx3 = ep.subscribe_path_changes(peer);
+
+    let stats = ep.endpoint_stats();
+    assert_eq!(
+        stats.active_path_watchers, 1,
+        "one live watcher per peer expected; got {} (leaked/over-counted watchers)",
+        stats.active_path_watchers
+    );
+    assert_eq!(
+        stats.active_path_subscriptions, 1,
+        "one subscription entry per peer expected"
+    );
+
+    ep.close().await;
+}
+
+/// Regression: #298 — after unsubscribing, the watcher gauge must return to
+/// zero (each live watcher counted once, decremented on unsubscribe/drop).
+#[tokio::test]
+async fn unsubscribe_decrements_watcher_gauge_to_zero() {
+    let ep = bind_disabled().await;
+    let peer = "test-peer-node-id";
+
+    let rx1 = ep.subscribe_path_changes(peer);
+    let rx2 = ep.subscribe_path_changes(peer);
+    assert_eq!(ep.endpoint_stats().active_path_watchers, 1);
+
+    // Drop receivers and unsubscribe so the watcher observes closure and exits.
+    drop(rx1);
+    drop(rx2);
+    ep.unsubscribe_path_changes(peer);
+
+    // Watcher wakes at most every ~200 ms; poll until it exits.
+    let mut watchers = usize::MAX;
+    for _ in 0..50 {
+        watchers = ep.endpoint_stats().active_path_watchers;
+        if watchers == 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        watchers, 0,
+        "watcher gauge should return to zero after unsubscribe, got {watchers}"
+    );
+
+    ep.close().await;
+}


### PR DESCRIPTION
## Summary

Fixes a watcher-task leak and `active_path_watchers` over-count when `subscribe_path_changes` is called repeatedly for the same peer.

## Root cause

In `crates/iroh-http-core/src/endpoint/observe.rs`, `subscribe_path_changes` unconditionally spawned a new watcher task and ran `active_path_watchers.fetch_add(1, …)` on every call. The comment claimed the "old watcher exits when it detects `is_closed()`", but that never happened: the old watcher polls `path_subs.get(&nid)` by node-id key, which — after the re-subscribe swapped in a fresh, non-closed sender — always reported not-closed. So each re-subscribe:

- leaked the previous watcher task (it never exited), and
- incremented `active_path_watchers`, so the gauge grew without bound and never reflected the true number of live watchers.

## Fix

`DashMap::insert` returns the previous value. When a sender already existed for the peer, a watcher is already live, so we replace only the sender and return early — no new task is spawned and the gauge is not bumped. The running watcher picks up the new sender on its next poll. `active_path_watchers` now counts exactly one live watcher per peer and is decremented on unsubscribe/drop as before.

Change is confined to `crates/iroh-http-core/src/endpoint/observe.rs` plus a new regression test file.

## Verification

- New regression tests in `crates/iroh-http-core/tests/observe.rs`:
  - `repeated_subscribe_same_peer_counts_one_watcher` — failed pre-fix (`active_path_watchers` = 3 after 3 subscribes), passes post-fix (= 1).
  - `unsubscribe_decrements_watcher_gauge_to_zero` — failed pre-fix (stuck at 2), passes post-fix (returns to 0).
- `npm run ci` — full suite passes (fmt, clippy, rust/tauri tests, deny, audit, bench smoke, feature checks, builds, typecheck, lockfile, node/deno/interop tests).

Closes #298