### PR TITLE
refactor(core): extract error/crypto/encoding/addr types out of lib.rs (#198)

### DIFF
--- a/crates/iroh-http-core/src/addr.rs
+++ b/crates/iroh-http-core/src/addr.rs
@@ -1,0 +1,53 @@
+//! Node address parsing: tickets, bare node IDs, and JSON address info.
+
+use crate::encoding::parse_node_id;
+use crate::{CoreError, IrohEndpoint, NodeAddrInfo};
+
+/// Generate a ticket string for the given endpoint.
+///
+/// ISS-025: returns `Result` so serialization failures are surfaced to callers
+/// instead of being masked as empty strings.
+pub fn node_ticket(ep: &IrohEndpoint) -> Result<String, CoreError> {
+    let info = ep.node_addr();
+    serde_json::to_string(&info)
+        .map_err(|e| CoreError::internal(format!("failed to serialize node ticket: {e}")))
+}
+
+/// Parsed node address from a ticket string, bare node ID, or JSON address info.
+pub struct ParsedNodeAddr {
+    pub node_id: iroh::PublicKey,
+    pub direct_addrs: Vec<std::net::SocketAddr>,
+}
+
+/// Parse a string that may be a bare node ID, a ticket string (JSON-encoded
+/// `NodeAddrInfo`), or a JSON object with `id` and `addrs` fields.
+///
+/// ISS-023: malformed entries that look like socket addresses but fail to parse
+/// cause a deterministic error. Entries that are clearly not socket addresses
+/// (e.g. relay URLs containing `://`) are silently skipped and handled
+/// elsewhere in the protocol stack.
+pub fn parse_node_addr(s: &str) -> Result<ParsedNodeAddr, CoreError> {
+    if let Ok(info) = serde_json::from_str::<NodeAddrInfo>(s) {
+        let node_id = parse_node_id(&info.id)?;
+        let mut direct_addrs = Vec::new();
+        for addr_str in &info.addrs {
+            // Skip relay URLs — they are handled by the relay subsystem.
+            if addr_str.contains("://") {
+                continue;
+            }
+            let addr = addr_str
+                .parse::<std::net::SocketAddr>()
+                .map_err(|_| CoreError::invalid_input(format!("malformed address: {addr_str}")))?;
+            direct_addrs.push(addr);
+        }
+        return Ok(ParsedNodeAddr {
+            node_id,
+            direct_addrs,
+        });
+    }
+    let node_id = parse_node_id(s)?;
+    Ok(ParsedNodeAddr {
+        node_id,
+        direct_addrs: Vec::new(),
+    })
+}

--- a/crates/iroh-http-core/src/crypto.rs
+++ b/crates/iroh-http-core/src/crypto.rs
@@ -1,0 +1,38 @@
+//! Ed25519 key operations: signing, verification, and key generation.
+//!
+//! Each helper is panic-guarded so a fault in the underlying crypto library
+//! surfaces as a [`CoreError`] (or `false`) rather than unwinding across the
+//! FFI boundary.
+
+use crate::CoreError;
+
+/// Sign arbitrary bytes with a 32-byte Ed25519 secret key.
+/// Returns a 64-byte signature, or `Err` if the underlying crypto panics.
+pub fn secret_key_sign(secret_key_bytes: &[u8; 32], data: &[u8]) -> Result<[u8; 64], CoreError> {
+    std::panic::catch_unwind(|| {
+        let key = iroh::SecretKey::from_bytes(secret_key_bytes);
+        key.sign(data).to_bytes()
+    })
+    .map_err(|_| CoreError::internal("secret_key_sign panicked"))
+}
+
+/// Verify a 64-byte Ed25519 signature against a 32-byte public key.
+/// Returns `true` on success, `false` on any failure (including panics).
+pub fn public_key_verify(public_key_bytes: &[u8; 32], data: &[u8], sig_bytes: &[u8; 64]) -> bool {
+    std::panic::catch_unwind(|| {
+        let Ok(key) = iroh::PublicKey::from_bytes(public_key_bytes) else {
+            return false;
+        };
+        let sig = iroh::Signature::from_bytes(sig_bytes);
+        key.verify(data, &sig).is_ok()
+    })
+    .unwrap_or(false)
+}
+
+/// Generate a fresh Ed25519 secret key. Returns 32 raw bytes, or `Err` if the RNG panics.
+pub fn generate_secret_key() -> Result<[u8; 32], CoreError> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        iroh::SecretKey::generate().to_bytes()
+    }))
+    .map_err(|_| CoreError::internal("generate_secret_key panicked"))
+}

--- a/crates/iroh-http-core/src/encoding.rs
+++ b/crates/iroh-http-core/src/encoding.rs
@@ -1,0 +1,65 @@
+//! Base32 encoding utilities and node-id parsing.
+//!
+//! All base32 uses lowercase RFC 4648 without padding, the canonical form for
+//! node identifiers throughout the crate.
+
+use crate::CoreError;
+
+/// Encode bytes as lowercase RFC 4648 base32 (no padding).
+pub fn base32_encode(bytes: &[u8]) -> String {
+    base32::encode(base32::Alphabet::Rfc4648Lower { padding: false }, bytes)
+}
+
+/// Decode an RFC 4648 base32 string (no padding, case-insensitive) to bytes.
+pub(crate) fn base32_decode(s: &str) -> Result<Vec<u8>, String> {
+    base32::decode(base32::Alphabet::Rfc4648Lower { padding: false }, s)
+        .ok_or_else(|| format!("invalid base32 string: {s}"))
+}
+
+/// Parse a base32 node-id string into an `iroh::PublicKey`.
+pub(crate) fn parse_node_id(s: &str) -> Result<iroh::PublicKey, CoreError> {
+    let bytes = base32_decode(s).map_err(CoreError::invalid_input)?;
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| CoreError::invalid_input("node-id must be 32 bytes"))?;
+    iroh::PublicKey::from_bytes(&arr).map_err(|e| CoreError::invalid_input(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base32_round_trip() {
+        let original: Vec<u8> = (0..32).collect();
+        let encoded = base32_encode(&original);
+        let decoded = base32_decode(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn base32_empty() {
+        let encoded = base32_encode(&[]);
+        assert_eq!(encoded, "");
+        let decoded = base32_decode("").unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn base32_decode_invalid_char() {
+        let result = base32_decode("!!!invalid!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_node_id_invalid_base32() {
+        let result = parse_node_id("!!!not-base32!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_node_id_wrong_length() {
+        let result = parse_node_id("aa");
+        assert!(result.is_err());
+    }
+}

--- a/crates/iroh-http-core/src/error.rs
+++ b/crates/iroh-http-core/src/error.rs
@@ -1,0 +1,99 @@
+//! Structured error types shared across the crate and the FFI boundary.
+//!
+//! [`CoreError`] pairs a machine-readable [`ErrorCode`] with human-readable
+//! detail. Platform adapters match on the code directly — no string parsing.
+
+/// Machine-readable error codes for the FFI boundary.
+///
+/// Platform adapters match on this directly — no string parsing needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorCode {
+    InvalidInput,
+    ConnectionFailed,
+    Timeout,
+    BodyTooLarge,
+    HeaderTooLarge,
+    PeerRejected,
+    Cancelled,
+    Internal,
+}
+
+/// Structured error returned by core functions.
+///
+/// `code` is machine-readable. `message` carries human-readable detail.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{code:?}: {message}")]
+pub struct CoreError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl CoreError {
+    pub fn invalid_input(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::InvalidInput,
+            message: detail.to_string(),
+        }
+    }
+    pub fn connection_failed(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::ConnectionFailed,
+            message: detail.to_string(),
+        }
+    }
+    pub fn timeout(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::Timeout,
+            message: detail.to_string(),
+        }
+    }
+    pub fn body_too_large(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::BodyTooLarge,
+            message: detail.to_string(),
+        }
+    }
+    pub fn header_too_large(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::HeaderTooLarge,
+            message: detail.to_string(),
+        }
+    }
+    pub fn peer_rejected(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::PeerRejected,
+            message: detail.to_string(),
+        }
+    }
+    pub fn internal(detail: impl std::fmt::Display) -> Self {
+        CoreError {
+            code: ErrorCode::Internal,
+            message: detail.to_string(),
+        }
+    }
+    pub fn invalid_handle(handle: u64) -> Self {
+        CoreError {
+            code: ErrorCode::InvalidInput,
+            message: format!("unknown handle: {handle}"),
+        }
+    }
+    pub fn cancelled() -> Self {
+        CoreError {
+            code: ErrorCode::Cancelled,
+            message: "aborted".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_error_display() {
+        let e = CoreError::timeout("30s elapsed");
+        assert!(e.to_string().contains("Timeout"));
+        assert!(e.to_string().contains("30s elapsed"));
+    }
+}

--- a/crates/iroh-http-core/src/lib.rs
+++ b/crates/iroh-http-core/src/lib.rs
@@ -19,6 +19,12 @@ pub mod endpoint;
 pub(crate) mod ffi;
 pub(crate) mod http;
 
+// Cross-cutting utility modules (extracted from lib.rs, see #198).
+mod addr;
+mod crypto;
+mod encoding;
+mod error;
+
 // Thin re-export modules preserving external API paths.
 pub mod events {
     pub use crate::http::events::*;
@@ -54,89 +60,7 @@ pub use http::server::stack::{CompressionOptions, StackConfig};
 pub use registry::{get_endpoint, insert_endpoint, remove_endpoint};
 
 // ── Structured error types ────────────────────────────────────────────────────
-
-/// Machine-readable error codes for the FFI boundary.
-///
-/// Platform adapters match on this directly — no string parsing needed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ErrorCode {
-    InvalidInput,
-    ConnectionFailed,
-    Timeout,
-    BodyTooLarge,
-    HeaderTooLarge,
-    PeerRejected,
-    Cancelled,
-    Internal,
-}
-
-/// Structured error returned by core functions.
-///
-/// `code` is machine-readable. `message` carries human-readable detail.
-#[derive(Debug, Clone, thiserror::Error)]
-#[error("{code:?}: {message}")]
-pub struct CoreError {
-    pub code: ErrorCode,
-    pub message: String,
-}
-
-impl CoreError {
-    pub fn invalid_input(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::InvalidInput,
-            message: detail.to_string(),
-        }
-    }
-    pub fn connection_failed(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::ConnectionFailed,
-            message: detail.to_string(),
-        }
-    }
-    pub fn timeout(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::Timeout,
-            message: detail.to_string(),
-        }
-    }
-    pub fn body_too_large(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::BodyTooLarge,
-            message: detail.to_string(),
-        }
-    }
-    pub fn header_too_large(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::HeaderTooLarge,
-            message: detail.to_string(),
-        }
-    }
-    pub fn peer_rejected(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::PeerRejected,
-            message: detail.to_string(),
-        }
-    }
-    pub fn internal(detail: impl std::fmt::Display) -> Self {
-        CoreError {
-            code: ErrorCode::Internal,
-            message: detail.to_string(),
-        }
-    }
-    pub fn invalid_handle(handle: u64) -> Self {
-        CoreError {
-            code: ErrorCode::InvalidInput,
-            message: format!("unknown handle: {handle}"),
-        }
-    }
-    pub fn cancelled() -> Self {
-        CoreError {
-            code: ErrorCode::Cancelled,
-            message: "aborted".to_string(),
-        }
-    }
-}
+pub use error::{CoreError, ErrorCode};
 
 // ── ALPN protocol identifiers ─────────────────────────────────────────────────
 
@@ -154,153 +78,11 @@ pub const ALPN_DUPLEX_STR: &str = "iroh-http/2-duplex";
 pub const KNOWN_ALPNS: &[&str] = &[ALPN_STR, ALPN_DUPLEX_STR];
 
 // ── Key operations ───────────────────────────────────────────────────────────
+pub use crypto::{generate_secret_key, public_key_verify, secret_key_sign};
 
-/// Sign arbitrary bytes with a 32-byte Ed25519 secret key.
-/// Returns a 64-byte signature, or `Err` if the underlying crypto panics.
-pub fn secret_key_sign(secret_key_bytes: &[u8; 32], data: &[u8]) -> Result<[u8; 64], CoreError> {
-    std::panic::catch_unwind(|| {
-        let key = iroh::SecretKey::from_bytes(secret_key_bytes);
-        key.sign(data).to_bytes()
-    })
-    .map_err(|_| CoreError::internal("secret_key_sign panicked"))
-}
+// ── Encoding utilities ────────────────────────────────────────────────────────
+pub(crate) use encoding::base32_decode;
+pub use encoding::base32_encode;
 
-/// Verify a 64-byte Ed25519 signature against a 32-byte public key.
-/// Returns `true` on success, `false` on any failure (including panics).
-pub fn public_key_verify(public_key_bytes: &[u8; 32], data: &[u8], sig_bytes: &[u8; 64]) -> bool {
-    std::panic::catch_unwind(|| {
-        let Ok(key) = iroh::PublicKey::from_bytes(public_key_bytes) else {
-            return false;
-        };
-        let sig = iroh::Signature::from_bytes(sig_bytes);
-        key.verify(data, &sig).is_ok()
-    })
-    .unwrap_or(false)
-}
-
-/// Generate a fresh Ed25519 secret key. Returns 32 raw bytes, or `Err` if the RNG panics.
-pub fn generate_secret_key() -> Result<[u8; 32], CoreError> {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        iroh::SecretKey::generate().to_bytes()
-    }))
-    .map_err(|_| CoreError::internal("generate_secret_key panicked"))
-}
-
-// ── Encode bytes as base32 ────────────────────────────────────────────────────
-
-/// Encode bytes as lowercase RFC 4648 base32 (no padding).
-pub fn base32_encode(bytes: &[u8]) -> String {
-    base32::encode(base32::Alphabet::Rfc4648Lower { padding: false }, bytes)
-}
-
-/// Decode an RFC 4648 base32 string (no padding, case-insensitive) to bytes.
-pub(crate) fn base32_decode(s: &str) -> Result<Vec<u8>, String> {
-    base32::decode(base32::Alphabet::Rfc4648Lower { padding: false }, s)
-        .ok_or_else(|| format!("invalid base32 string: {s}"))
-}
-
-/// Parse a base32 node-id string into an `iroh::PublicKey`.
-pub(crate) fn parse_node_id(s: &str) -> Result<iroh::PublicKey, CoreError> {
-    let bytes = base32_decode(s).map_err(CoreError::invalid_input)?;
-    let arr: [u8; 32] = bytes
-        .try_into()
-        .map_err(|_| CoreError::invalid_input("node-id must be 32 bytes"))?;
-    iroh::PublicKey::from_bytes(&arr).map_err(|e| CoreError::invalid_input(e.to_string()))
-}
-
-// ── Node tickets ──────────────────────────────────────────────────────────────
-
-/// Generate a ticket string for the given endpoint.
-///
-/// ISS-025: returns `Result` so serialization failures are surfaced to callers
-/// instead of being masked as empty strings.
-pub fn node_ticket(ep: &IrohEndpoint) -> Result<String, CoreError> {
-    let info = ep.node_addr();
-    serde_json::to_string(&info)
-        .map_err(|e| CoreError::internal(format!("failed to serialize node ticket: {e}")))
-}
-
-/// Parsed node address from a ticket string, bare node ID, or JSON address info.
-pub struct ParsedNodeAddr {
-    pub node_id: iroh::PublicKey,
-    pub direct_addrs: Vec<std::net::SocketAddr>,
-}
-
-/// Parse a string that may be a bare node ID, a ticket string (JSON-encoded
-/// `NodeAddrInfo`), or a JSON object with `id` and `addrs` fields.
-///
-/// ISS-023: malformed entries that look like socket addresses but fail to parse
-/// cause a deterministic error. Entries that are clearly not socket addresses
-/// (e.g. relay URLs containing `://`) are silently skipped and handled
-/// elsewhere in the protocol stack.
-pub fn parse_node_addr(s: &str) -> Result<ParsedNodeAddr, CoreError> {
-    if let Ok(info) = serde_json::from_str::<NodeAddrInfo>(s) {
-        let node_id = parse_node_id(&info.id)?;
-        let mut direct_addrs = Vec::new();
-        for addr_str in &info.addrs {
-            // Skip relay URLs — they are handled by the relay subsystem.
-            if addr_str.contains("://") {
-                continue;
-            }
-            let addr = addr_str
-                .parse::<std::net::SocketAddr>()
-                .map_err(|_| CoreError::invalid_input(format!("malformed address: {addr_str}")))?;
-            direct_addrs.push(addr);
-        }
-        return Ok(ParsedNodeAddr {
-            node_id,
-            direct_addrs,
-        });
-    }
-    let node_id = parse_node_id(s)?;
-    Ok(ParsedNodeAddr {
-        node_id,
-        direct_addrs: Vec::new(),
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn base32_round_trip() {
-        let original: Vec<u8> = (0..32).collect();
-        let encoded = base32_encode(&original);
-        let decoded = base32_decode(&encoded).unwrap();
-        assert_eq!(decoded, original);
-    }
-
-    #[test]
-    fn base32_empty() {
-        let encoded = base32_encode(&[]);
-        assert_eq!(encoded, "");
-        let decoded = base32_decode("").unwrap();
-        assert!(decoded.is_empty());
-    }
-
-    #[test]
-    fn base32_decode_invalid_char() {
-        let result = base32_decode("!!!invalid!!!");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_node_id_invalid_base32() {
-        let result = parse_node_id("!!!not-base32!!!");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_node_id_wrong_length() {
-        let result = parse_node_id("aa");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn core_error_display() {
-        let e = CoreError::timeout("30s elapsed");
-        assert!(e.to_string().contains("Timeout"));
-        assert!(e.to_string().contains("30s elapsed"));
-    }
-}
+// ── Node address parsing ──────────────────────────────────────────────────────
+pub use addr::{node_ticket, parse_node_addr, ParsedNodeAddr};

--- a/crates/iroh-http-core/tests/architecture.rs
+++ b/crates/iroh-http-core/tests/architecture.rs
@@ -4,10 +4,12 @@
 //!    from `crate::ffi::*`. The FFI bridge wraps the pure-Rust HTTP
 //!    layer, never the reverse.
 //! 2. **Canonical root layout.** The only entries directly under
-//!    `crates/iroh-http-core/src/` are `lib.rs`, `endpoint.rs`,
-//!    `http/`, and `ffi/`. Every other file declares a side. This
-//!    prevents the kind of drift that produced the original 979-LoC
-//!    `server.rs` and 998-LoC `stream.rs`.
+//!    `crates/iroh-http-core/src/` are `lib.rs`, `endpoint/`,
+//!    `http/`, `ffi/`, and the cross-cutting utility modules extracted
+//!    in #198 (`error.rs`, `crypto.rs`, `encoding.rs`, `addr.rs`).
+//!    Every other file declares a side. This prevents the kind of
+//!    drift that produced the original 979-LoC `server.rs` and
+//!    998-LoC `stream.rs`.
 //!
 //! Slice history (TEMPORARY_EXCEPTIONS evolution):
 //!
@@ -92,14 +94,25 @@ fn walk(dir: &Path, f: &mut impl FnMut(&Path)) {
 
 /// Slice E (#187) acceptance #6: assert the canonical root layout.
 ///
-/// Only `lib.rs`, `endpoint.rs`, `http/`, and `ffi/` may live directly
-/// under `crates/iroh-http-core/src/`. Any other file or folder is a
-/// structural drift that the reviewer should have flagged. Adding new
-/// top-level modules requires editing both this allowlist *and* the
-/// epic acceptance criteria — that intentional friction is the point.
+/// Only `lib.rs`, the `http/`, `ffi/`, and `endpoint/` module trees, and the
+/// cross-cutting utility modules extracted in #198 (`error.rs`, `crypto.rs`,
+/// `encoding.rs`, `addr.rs`) may live directly under
+/// `crates/iroh-http-core/src/`. Any other file or folder is a structural
+/// drift that the reviewer should have flagged. Adding new top-level modules
+/// requires editing both this allowlist *and* the epic acceptance criteria —
+/// that intentional friction is the point.
 #[test]
 fn crate_root_has_canonical_layout() {
-    const ALLOWED: &[&str] = &["lib.rs", "endpoint", "http", "ffi"];
+    const ALLOWED: &[&str] = &[
+        "lib.rs",
+        "endpoint",
+        "http",
+        "ffi",
+        "error.rs",
+        "crypto.rs",
+        "encoding.rs",
+        "addr.rs",
+    ];
 
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let src_dir = Path::new(manifest_dir).join("src");


### PR DESCRIPTION
## Summary

Pure refactor. Per epic #182, `crates/iroh-http-core/src/lib.rs` is meant to define the crate's dependency direction and re-export its API surface — not host cross-cutting definitions. It had accumulated ~170 LoC of type/function definitions. This PR extracts them into dedicated, cohesive modules and leaves `lib.rs` as thin re-exports.

No behavior change, no public-API change.

## What moved where

| New module | Items |
|---|---|
| `src/error.rs` | `CoreError`, `ErrorCode` (+ `core_error_display` test) |
| `src/crypto.rs` | `secret_key_sign`, `public_key_verify`, `generate_secret_key` |
| `src/encoding.rs` | `base32_encode`, `base32_decode`, `parse_node_id` (+ base32 round-trip/empty/invalid and node-id parse tests) |
| `src/addr.rs` | `node_ticket`, `parse_node_addr`, `ParsedNodeAddr` |

The ALPN constants (`ALPN`, `ALPN_DUPLEX`, `ALPN_STR`, `ALPN_DUPLEX_STR`, `KNOWN_ALPNS`) stay in `lib.rs` — they're small protocol identifiers, not the cross-cutting types called out in the issue.

## Invariant preserved: zero public-API change

`lib.rs` re-exports every previously-public item at its **same crate path** via `pub use`, so external crates (adapters, `iroh-http-adapter`) resolve them exactly as before:

- `pub use error::{CoreError, ErrorCode};`
- `pub use crypto::{generate_secret_key, public_key_verify, secret_key_sign};`
- `pub use encoding::base32_encode;`
- `pub use addr::{node_ticket, parse_node_addr, ParsedNodeAddr};`

The internal `pub(crate)` path `crate::base32_decode` is preserved via `pub(crate) use encoding::base32_decode;` for sibling modules (`endpoint/observe.rs`). All `crate::X` references from other core modules keep resolving through these root re-exports — no sibling files were touched.

`tests/architecture.rs` canonical-layout allowlist was updated to include the four new utility modules, exactly as its own doc comment instructs when adding top-level modules.

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `npm run ci` (full CI mirror: fmt, lint, rust/tauri/node/deno tests, deny, audit, bench smoke, feature checks, builds, typecheck, lockfile, interop) — **All checks passed**
- Moved unit tests run under their new module paths (`encoding::tests::*`, `error::tests::*`) and pass
- Build churn (NAPI `index.js` codegen, `package-lock.json`/`deno.lock` flips) reverted; no version-field bumps

Closes #198