### PR TITLE
feat(adapter): unify fetch/serve validation & caps into iroh-http-adapter (#289)

### DIFF
--- a/crates/iroh-http-adapter/src/lib.rs
+++ b/crates/iroh-http-adapter/src/lib.rs
@@ -20,6 +20,10 @@ pub const MAX_HEADER_VALUE_LEN: usize = 8_192;
 pub const MAX_TIMEOUT_MS: u64 = 300_000;
 /// Maximum adapter-level body cap in bytes.
 pub const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum total simultaneous connections a served endpoint will accept.
+pub const MAX_TOTAL_CONNECTIONS: usize = 100_000;
+/// Maximum header block size in bytes accepted for a served endpoint.
+pub const MAX_HEADER_BYTES: usize = 1_048_576;
 /// Maximum node-id / ticket string length in bytes accepted at an adapter boundary.
 pub const MAX_NODE_ID_LEN: usize = 128;
 /// Maximum request URL length in bytes accepted at an adapter boundary.

--- a/crates/iroh-http-adapter/src/lib.rs
+++ b/crates/iroh-http-adapter/src/lib.rs
@@ -20,6 +20,16 @@ pub const MAX_HEADER_VALUE_LEN: usize = 8_192;
 pub const MAX_TIMEOUT_MS: u64 = 300_000;
 /// Maximum adapter-level body cap in bytes.
 pub const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum node-id / ticket string length in bytes accepted at an adapter boundary.
+pub const MAX_NODE_ID_LEN: usize = 128;
+/// Maximum request URL length in bytes accepted at an adapter boundary.
+pub const MAX_URL_LEN: usize = 8_192;
+/// Maximum HTTP method length in bytes accepted at an adapter boundary.
+pub const MAX_METHOD_LEN: usize = 32;
+/// Maximum number of direct addresses accepted at an adapter boundary.
+pub const MAX_DIRECT_ADDRS: usize = 32;
+/// Maximum length of a single direct address string in bytes.
+pub const MAX_DIRECT_ADDR_LEN: usize = 256;
 
 const UNDELIVERABLE_STATUS: u16 = 503;
 const UNDELIVERABLE_HEADERS: [(&str, &str); 1] = [("content-length", "0")];
@@ -51,6 +61,10 @@ pub fn send_undeliverable_rejection(
 /// Adapter-boundary input validation error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AdapterInputError {
+    /// Node/public-key input failed coarse boundary validation.
+    InvalidNodeId,
+    /// URL input failed coarse boundary validation.
+    InvalidUrl,
     /// Caller-provided input exceeds a hard boundary limit.
     InputTooLarge {
         field: &'static str,
@@ -67,6 +81,8 @@ impl AdapterInputError {
     /// Stable JSON error code used by JS/TS adapters.
     pub fn code(&self) -> &'static str {
         match self {
+            AdapterInputError::InvalidNodeId => "INVALID_NODE_ID",
+            AdapterInputError::InvalidUrl => "INVALID_URL",
             AdapterInputError::InputTooLarge { .. } => "INPUT_TOO_LARGE",
             AdapterInputError::InvalidEncoding { .. } => "INVALID_ENCODING",
             AdapterInputError::InvalidArgument { .. } => "INVALID_ARGUMENT",
@@ -76,6 +92,8 @@ impl AdapterInputError {
     /// Human-readable validation message.
     pub fn message(&self) -> String {
         match self {
+            AdapterInputError::InvalidNodeId => "invalid node id".to_string(),
+            AdapterInputError::InvalidUrl => "invalid url".to_string(),
             AdapterInputError::InputTooLarge { field, max, got } => {
                 format!("{field} exceeds max size {max} (got {got})")
             }
@@ -120,6 +138,53 @@ pub fn validate_header_rows(
         pairs.push((name.clone(), value.clone()));
     }
     Ok(pairs)
+}
+
+/// Validate a caller-supplied node id (base32 public key or JSON ticket).
+///
+/// A payload that begins with `{` (after leading whitespace) is treated as a
+/// JSON ticket / `NodeAddrInfo` blob and parsed by core; only boundary-level
+/// size and encoding constraints are enforced here.  Otherwise the string must
+/// be lowercase base32 (`a-z`, `2-7`).
+pub fn validate_node_id(node_id: &str) -> Result<(), AdapterInputError> {
+    validate_bounded_string("nodeId", node_id, MAX_NODE_ID_LEN)?;
+    if node_id.trim_start().starts_with('{') {
+        return Ok(());
+    }
+    let valid = node_id
+        .bytes()
+        .all(|b| matches!(b, b'a'..=b'z' | b'2'..=b'7'));
+    if !valid {
+        return Err(AdapterInputError::InvalidNodeId);
+    }
+    Ok(())
+}
+
+/// Validate a caller-supplied request URL against boundary size/encoding limits.
+pub fn validate_url(url: &str) -> Result<(), AdapterInputError> {
+    validate_bounded_string("url", url, MAX_URL_LEN)
+}
+
+/// Validate a caller-supplied HTTP method against boundary size/encoding limits.
+pub fn validate_method(method: &str) -> Result<(), AdapterInputError> {
+    validate_bounded_string("method", method, MAX_METHOD_LEN)
+}
+
+/// Validate the optional list of caller-supplied direct addresses.
+pub fn validate_direct_addrs(direct_addrs: &Option<Vec<String>>) -> Result<(), AdapterInputError> {
+    if let Some(addrs) = direct_addrs {
+        if addrs.len() > MAX_DIRECT_ADDRS {
+            return Err(AdapterInputError::InputTooLarge {
+                field: "directAddrs",
+                max: MAX_DIRECT_ADDRS,
+                got: addrs.len(),
+            });
+        }
+        for addr in addrs {
+            validate_bounded_string("directAddr", addr, MAX_DIRECT_ADDR_LEN)?;
+        }
+    }
+    Ok(())
 }
 
 /// Validate and convert an f64 option to a non-negative u64.
@@ -386,5 +451,88 @@ mod tests {
                 })
             ));
         }
+    }
+
+    #[test]
+    fn validate_node_id_accepts_base32_and_ticket() {
+        assert_eq!(validate_node_id("abcdefghijklmnopqrstuvwxyz234567"), Ok(()));
+        // JSON ticket / NodeAddrInfo blob bypasses the base32 charset check.
+        assert_eq!(validate_node_id("  {\"nodeId\":\"x\"}"), Ok(()));
+    }
+
+    #[test]
+    fn validate_node_id_rejects_bad_charset_and_bounds() {
+        assert_eq!(
+            validate_node_id("bad-node-id!"),
+            Err(AdapterInputError::InvalidNodeId)
+        );
+        assert!(matches!(
+            validate_node_id(""),
+            Err(AdapterInputError::InvalidArgument {
+                field: "nodeId",
+                ..
+            })
+        ));
+        let long = "a".repeat(MAX_NODE_ID_LEN + 1);
+        assert!(matches!(
+            validate_node_id(&long),
+            Err(AdapterInputError::InputTooLarge {
+                field: "nodeId",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_url_enforces_bounds_and_encoding() {
+        assert_eq!(validate_url("httpi://peer/path"), Ok(()));
+        assert!(matches!(
+            validate_url("httpi://peer/\0x"),
+            Err(AdapterInputError::InvalidEncoding { field: "url" })
+        ));
+        let long = "u".repeat(MAX_URL_LEN + 1);
+        assert!(matches!(
+            validate_url(&long),
+            Err(AdapterInputError::InputTooLarge { field: "url", .. })
+        ));
+    }
+
+    #[test]
+    fn validate_method_enforces_bounds() {
+        assert_eq!(validate_method("POST"), Ok(()));
+        let long = "M".repeat(MAX_METHOD_LEN + 1);
+        assert!(matches!(
+            validate_method(&long),
+            Err(AdapterInputError::InputTooLarge {
+                field: "method",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_direct_addrs_enforces_count_and_element_bounds() {
+        assert_eq!(validate_direct_addrs(&None), Ok(()));
+        assert_eq!(
+            validate_direct_addrs(&Some(vec!["127.0.0.1:1234".to_string()])),
+            Ok(())
+        );
+        let too_many = vec!["1.2.3.4:5".to_string(); MAX_DIRECT_ADDRS + 1];
+        assert!(matches!(
+            validate_direct_addrs(&Some(too_many)),
+            Err(AdapterInputError::InputTooLarge {
+                field: "directAddrs",
+                max: MAX_DIRECT_ADDRS,
+                ..
+            })
+        ));
+        let long = "a".repeat(MAX_DIRECT_ADDR_LEN + 1);
+        assert!(matches!(
+            validate_direct_addrs(&Some(vec![long])),
+            Err(AdapterInputError::InputTooLarge {
+                field: "directAddr",
+                ..
+            })
+        ));
     }
 }

--- a/crates/iroh-http-adapter/src/lib.rs
+++ b/crates/iroh-http-adapter/src/lib.rs
@@ -245,6 +245,20 @@ pub fn safe_f64_to_usize(
     Ok(value as usize)
 }
 
+/// Validate a compression level, rejecting negative values and returning the
+/// unsigned level the core compression config expects. Centralizes the
+/// non-negative check that all three adapters previously hand-rolled (or, in
+/// Tauri's case, delegated to a generic serde error).
+pub fn validate_compression_level(level: i32) -> Result<u32, AdapterInputError> {
+    if level < 0 {
+        return Err(AdapterInputError::InvalidArgument {
+            field: "compressionLevel",
+            reason: format!("must be non-negative, got {level}"),
+        });
+    }
+    Ok(level as u32)
+}
+
 fn validate_bounded_string(
     field: &'static str,
     value: &str,
@@ -535,6 +549,19 @@ mod tests {
             validate_direct_addrs(&Some(vec![long])),
             Err(AdapterInputError::InputTooLarge {
                 field: "directAddr",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_compression_level_rejects_negative() {
+        assert_eq!(validate_compression_level(0), Ok(0));
+        assert_eq!(validate_compression_level(9), Ok(9));
+        assert!(matches!(
+            validate_compression_level(-1),
+            Err(AdapterInputError::InvalidArgument {
+                field: "compressionLevel",
                 ..
             })
         ));

--- a/packages/iroh-http-deno/src/dispatch.rs
+++ b/packages/iroh-http-deno/src/dispatch.rs
@@ -70,9 +70,9 @@ fn insert_endpoint(ep: IrohEndpoint) -> u64 {
 
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
-    send_undeliverable_rejection, validate_direct_addrs, validate_header_rows, validate_method,
-    validate_node_id, validate_url, AdapterInputError, MAX_BODY_BYTES, MAX_HEADER_BYTES,
-    MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
+    send_undeliverable_rejection, validate_compression_level, validate_direct_addrs,
+    validate_header_rows, validate_method, validate_node_id, validate_url, AdapterInputError,
+    MAX_BODY_BYTES, MAX_HEADER_BYTES, MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
 };
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -381,18 +381,19 @@ async fn create_endpoint(p: Value) -> Value {
             || args.compression_level.is_some()
         {
             // ISS-020: validate compression level range before cast.
-            if let Some(level) = args.compression_level {
-                if level < 0 {
-                    return err(format!(
-                        "compressionLevel must be non-negative, got {level}"
-                    ));
-                }
-            }
+            let level = match args
+                .compression_level
+                .map(validate_compression_level)
+                .transpose()
+            {
+                Ok(v) => v,
+                Err(e) => return err_adapter(e),
+            };
             Some(iroh_http_core::CompressionOptions {
                 min_body_bytes: args
                     .compression_min_body_bytes
                     .unwrap_or(iroh_http_core::CompressionOptions::DEFAULT_MIN_BODY_BYTES),
-                level: args.compression_level.map(|v| v as u32),
+                level,
             })
         } else {
             None

--- a/packages/iroh-http-deno/src/dispatch.rs
+++ b/packages/iroh-http-deno/src/dispatch.rs
@@ -71,7 +71,8 @@ fn insert_endpoint(ep: IrohEndpoint) -> u64 {
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
     send_undeliverable_rejection, validate_direct_addrs, validate_header_rows, validate_method,
-    validate_node_id, validate_url, AdapterInputError, MAX_BODY_BYTES, MAX_TIMEOUT_MS,
+    validate_node_id, validate_url, AdapterInputError, MAX_BODY_BYTES, MAX_HEADER_BYTES,
+    MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
 };
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -94,6 +95,24 @@ fn err_core(e: iroh_http_core::CoreError) -> Value {
 
 fn err_adapter(e: AdapterInputError) -> Value {
     err_code(e.code(), e.message())
+}
+
+/// Coerce an optional f64 knob to a capped `u64`, matching the adapter contract.
+fn coerce_opt_u64(
+    value: Option<f64>,
+    field: &'static str,
+    max: u64,
+) -> Result<Option<u64>, AdapterInputError> {
+    value.map(|v| safe_f64_to_u64(v, field, max)).transpose()
+}
+
+/// Coerce an optional f64 knob to a capped `usize`, matching the adapter contract.
+fn coerce_opt_usize(
+    value: Option<f64>,
+    field: &'static str,
+    max: usize,
+) -> Result<Option<usize>, AdapterInputError> {
+    value.map(|v| safe_f64_to_usize(v, field, max)).transpose()
 }
 
 fn deliver_request_to_queue(handle: u64, ep: &IrohEndpoint, payload: RequestPayload) {
@@ -255,7 +274,7 @@ pub async fn dispatch(method: &str, payload: &[u8]) -> Value {
 #[serde(rename_all = "camelCase")]
 struct CreateEndpointPayload {
     key: Option<String>,
-    idle_timeout: Option<u64>,
+    idle_timeout: Option<f64>,
     relay_mode: Option<String>,
     relays: Option<Vec<String>>,
     bind_addrs: Option<Vec<String>>,
@@ -263,17 +282,17 @@ struct CreateEndpointPayload {
     dns_discovery_enabled: Option<bool>,
     channel_capacity: Option<usize>,
     max_chunk_size_bytes: Option<usize>,
-    handle_ttl: Option<u64>,
-    sweep_interval: Option<u64>,
+    handle_ttl: Option<f64>,
+    sweep_interval: Option<f64>,
     max_pooled_connections: Option<usize>,
-    pool_idle_timeout_ms: Option<u64>,
+    pool_idle_timeout_ms: Option<f64>,
     disable_networking: Option<bool>,
     proxy_url: Option<String>,
     proxy_from_env: Option<bool>,
     keylog: Option<bool>,
     compression_level: Option<i32>,
     compression_min_body_bytes: Option<usize>,
-    max_header_bytes: Option<usize>,
+    max_header_bytes: Option<f64>,
 }
 
 async fn create_endpoint(p: Value) -> Value {
@@ -301,13 +320,40 @@ async fn create_endpoint(p: Value) -> Value {
         }
     };
 
+    let idle_timeout_ms = match coerce_opt_u64(args.idle_timeout, "idleTimeout", MAX_TIMEOUT_MS) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let pool_idle_timeout_ms = match coerce_opt_u64(
+        args.pool_idle_timeout_ms,
+        "poolIdleTimeoutMs",
+        MAX_TIMEOUT_MS,
+    ) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let handle_ttl_ms = match coerce_opt_u64(args.handle_ttl, "handleTtl", MAX_TIMEOUT_MS) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let sweep_interval_ms =
+        match coerce_opt_u64(args.sweep_interval, "sweepInterval", MAX_TIMEOUT_MS) {
+            Ok(v) => v,
+            Err(e) => return err_adapter(e),
+        };
+    let max_header_size =
+        match coerce_opt_usize(args.max_header_bytes, "maxHeaderBytes", MAX_HEADER_BYTES) {
+            Ok(v) => v,
+            Err(e) => return err_adapter(e),
+        };
+
     let opts = NodeOptions {
         key,
         networking: NetworkingOptions {
             relay_mode: args.relay_mode,
             relays: args.relays.unwrap_or_default(),
             bind_addrs: args.bind_addrs.unwrap_or_default(),
-            idle_timeout_ms: args.idle_timeout,
+            idle_timeout_ms,
             proxy_url: args.proxy_url,
             proxy_from_env: args.proxy_from_env.unwrap_or(false),
             disabled: args.disable_networking.unwrap_or(false),
@@ -318,18 +364,18 @@ async fn create_endpoint(p: Value) -> Value {
         },
         pool: PoolOptions {
             max_connections: args.max_pooled_connections,
-            idle_timeout_ms: args.pool_idle_timeout_ms,
+            idle_timeout_ms: pool_idle_timeout_ms,
         },
         streaming: StreamingOptions {
             channel_capacity: args.channel_capacity,
             max_chunk_size_bytes: args.max_chunk_size_bytes,
             drain_timeout_ms: None,
-            handle_ttl_ms: args.handle_ttl,
-            sweep_interval_ms: args.sweep_interval,
+            handle_ttl_ms,
+            sweep_interval_ms,
         },
         capabilities: Vec::new(),
         keylog: args.keylog.unwrap_or(false),
-        max_header_size: args.max_header_bytes,
+        max_header_size,
         max_response_body_bytes: None,
         compression: if args.compression_min_body_bytes.is_some()
             || args.compression_level.is_some()
@@ -744,16 +790,51 @@ async fn serve_start(p: Value) -> Value {
     };
 
     // Parse optional serve options from payload.
+    let request_timeout_ms = match coerce_opt_u64(
+        p["requestTimeout"].as_f64(),
+        "requestTimeout",
+        MAX_TIMEOUT_MS,
+    ) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let max_request_body_wire_bytes = match coerce_opt_usize(
+        p["maxRequestBodyWireBytes"].as_f64(),
+        "maxRequestBodyWireBytes",
+        MAX_BODY_BYTES,
+    ) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let max_request_body_decoded_bytes = match coerce_opt_usize(
+        p["maxRequestBodyDecodedBytes"].as_f64(),
+        "maxRequestBodyDecodedBytes",
+        MAX_BODY_BYTES,
+    ) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let max_total_connections = match coerce_opt_usize(
+        p["maxTotalConnections"].as_f64(),
+        "maxTotalConnections",
+        MAX_TOTAL_CONNECTIONS,
+    ) {
+        Ok(v) => v,
+        Err(e) => return err_adapter(e),
+    };
+    let drain_timeout_ms =
+        match coerce_opt_u64(p["drainTimeout"].as_f64(), "drainTimeout", MAX_TIMEOUT_MS) {
+            Ok(v) => v,
+            Err(e) => return err_adapter(e),
+        };
     let serve_opts = iroh_http_core::ServeOptions {
         max_concurrency: p["maxConcurrency"].as_u64().map(|v| v as usize),
         max_connections_per_peer: p["maxConnectionsPerPeer"].as_u64().map(|v| v as usize),
-        request_timeout_ms: p["requestTimeout"].as_u64(),
-        max_request_body_wire_bytes: p["maxRequestBodyWireBytes"].as_u64().map(|v| v as usize),
-        max_request_body_decoded_bytes: p["maxRequestBodyDecodedBytes"]
-            .as_u64()
-            .map(|v| v as usize),
-        max_total_connections: p["maxTotalConnections"].as_u64().map(|v| v as usize),
-        drain_timeout_ms: p["drainTimeout"].as_u64(),
+        request_timeout_ms,
+        max_request_body_wire_bytes,
+        max_request_body_decoded_bytes,
+        max_total_connections,
+        drain_timeout_ms,
         load_shed: p["loadShed"].as_bool(),
         decompression: p["decompress"].as_bool(),
     };

--- a/packages/iroh-http-deno/src/dispatch.rs
+++ b/packages/iroh-http-deno/src/dispatch.rs
@@ -70,8 +70,8 @@ fn insert_endpoint(ep: IrohEndpoint) -> u64 {
 
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
-    send_undeliverable_rejection, validate_header_rows, AdapterInputError, MAX_BODY_BYTES,
-    MAX_TIMEOUT_MS,
+    send_undeliverable_rejection, validate_direct_addrs, validate_header_rows, validate_method,
+    validate_node_id, validate_url, AdapterInputError, MAX_BODY_BYTES, MAX_TIMEOUT_MS,
 };
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -653,6 +653,18 @@ async fn raw_fetch_impl(args: RawFetchPayload) -> Value {
         Ok(pairs) => pairs,
         Err(e) => return err_adapter(e),
     };
+    if let Err(e) = validate_node_id(&args.node_id) {
+        return err_adapter(e);
+    }
+    if let Err(e) = validate_url(&args.url) {
+        return err_adapter(e);
+    }
+    if let Err(e) = validate_method(&args.method) {
+        return err_adapter(e);
+    }
+    if let Err(e) = validate_direct_addrs(&args.direct_addrs) {
+        return err_adapter(e);
+    }
     let reader = args
         .req_body_handle
         .and_then(|h| ep.handles().claim_pending_reader(h));

--- a/packages/iroh-http-node/index.d.ts
+++ b/packages/iroh-http-node/index.d.ts
@@ -227,7 +227,7 @@ export interface JsServeOptions {
   maxRequestBodyDecodedBytes?: number
   /** Maximum total QUIC connections the server will accept.  Default: unlimited. */
   maxTotalConnections?: number
-  /** Drain timeout in milliseconds after shutdown signal.  Default: 5000. */
+  /** Drain timeout in milliseconds after shutdown signal.  Default: 30000. */
   drainTimeout?: number
   /** Enable load-shedding (reject with 503 when at capacity). */
   loadShed?: boolean

--- a/packages/iroh-http-node/src/lib.rs
+++ b/packages/iroh-http-node/src/lib.rs
@@ -66,7 +66,8 @@ use tokio::sync::Mutex as TokioMutex;
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64 as adapter_safe_f64_to_u64,
     safe_f64_to_usize as adapter_safe_f64_to_usize, send_undeliverable_rejection,
-    validate_header_rows, AdapterInputError, MAX_BODY_BYTES as ADAPTER_MAX_BODY_BYTES,
+    validate_direct_addrs, validate_header_rows, validate_method, validate_node_id, validate_url,
+    AdapterInputError, MAX_BODY_BYTES as ADAPTER_MAX_BODY_BYTES,
     MAX_TIMEOUT_MS as ADAPTER_MAX_TIMEOUT_MS,
 };
 
@@ -86,11 +87,7 @@ fn path_change_rxs() -> &'static PathRxMap {
 
 // ── Endpoint helpers ──────────────────────────────────────────────────────────
 
-const MAX_NODE_ID_LEN: usize = 128;
 const MAX_URL_LEN: usize = 8_192;
-const MAX_METHOD_LEN: usize = 32;
-const MAX_DIRECT_ADDRS: usize = 32;
-const MAX_DIRECT_ADDR_LEN: usize = 256;
 #[cfg(feature = "discovery")]
 const MAX_MDNS_SERVICE_NAME_LEN: usize = 128;
 const MAX_TIMEOUT_MS: u64 = 300_000;
@@ -100,10 +97,6 @@ const MAX_TOTAL_CONNECTIONS: usize = 100_000;
 
 #[derive(Debug)]
 enum FfiError {
-    /// Node/public-key input failed coarse boundary validation.
-    InvalidNodeId,
-    /// URL input failed coarse boundary validation.
-    InvalidUrl,
     /// Caller-provided input exceeds a hard boundary limit.
     InputTooLarge {
         field: &'static str,
@@ -122,8 +115,6 @@ enum FfiError {
 impl FfiError {
     fn code(&self) -> &'static str {
         match self {
-            FfiError::InvalidNodeId => "INVALID_NODE_ID",
-            FfiError::InvalidUrl => "INVALID_URL",
             FfiError::InputTooLarge { .. } => "INPUT_TOO_LARGE",
             FfiError::InvalidEncoding { .. } => "INVALID_ENCODING",
             FfiError::InvalidArgument { .. } => "INVALID_ARGUMENT",
@@ -134,8 +125,6 @@ impl FfiError {
 
     fn message(&self) -> String {
         match self {
-            FfiError::InvalidNodeId => "invalid node id".to_string(),
-            FfiError::InvalidUrl => "invalid url".to_string(),
             FfiError::InputTooLarge { field, max, got } => {
                 format!("{field} exceeds max size {max} (got {got})")
             }
@@ -188,53 +177,6 @@ fn validate_bounded_string(
     }
     if value.as_bytes().contains(&0) {
         return Err(FfiError::InvalidEncoding { field });
-    }
-    Ok(())
-}
-
-fn validate_node_id_input(node_id: &str) -> std::result::Result<(), FfiError> {
-    validate_bounded_string("nodeId", node_id, MAX_NODE_ID_LEN)?;
-    if node_id.trim_start().starts_with('{') {
-        // JSON ticket / NodeAddrInfo payload is parsed by core; we only enforce
-        // boundary-level size and encoding constraints here.
-        return Ok(());
-    }
-    let valid = node_id
-        .bytes()
-        .all(|b| matches!(b, b'a'..=b'z' | b'2'..=b'7'));
-    if !valid {
-        return Err(FfiError::InvalidNodeId);
-    }
-    Ok(())
-}
-
-fn validate_url_input(url: &str) -> std::result::Result<(), FfiError> {
-    validate_bounded_string("url", url, MAX_URL_LEN).map_err(|e| match e {
-        FfiError::InvalidArgument { .. }
-        | FfiError::InputTooLarge { .. }
-        | FfiError::InvalidEncoding { .. } => e,
-        _ => FfiError::InvalidUrl,
-    })
-}
-
-fn validate_method_input(method: &str) -> std::result::Result<(), FfiError> {
-    validate_bounded_string("method", method, MAX_METHOD_LEN)
-}
-
-fn validate_direct_addrs_input(
-    direct_addrs: &Option<Vec<String>>,
-) -> std::result::Result<(), FfiError> {
-    if let Some(addrs) = direct_addrs {
-        if addrs.len() > MAX_DIRECT_ADDRS {
-            return Err(FfiError::InputTooLarge {
-                field: "directAddrs",
-                max: MAX_DIRECT_ADDRS,
-                got: addrs.len(),
-            });
-        }
-        for addr in addrs {
-            validate_bounded_string("directAddr", addr, MAX_DIRECT_ADDR_LEN)?;
-        }
     }
     Ok(())
 }
@@ -880,7 +822,7 @@ pub async fn next_path_change(
 ) -> napi::Result<Option<String>> {
     let rxs = path_change_rxs();
 
-    validate_node_id_input(&node_id).map_err(ffi_invalid_arg)?;
+    validate_node_id(&node_id).map_err(ffi_adapter_invalid_arg)?;
     let ep = get_endpoint(endpoint_handle)?;
 
     let key = (endpoint_handle, node_id.clone());
@@ -917,7 +859,7 @@ pub async fn next_path_change(
 /// Unsubscribe from path changes for a specific peer.
 #[napi]
 pub fn unsubscribe_path_changes(endpoint_handle: u32, node_id: String) -> napi::Result<()> {
-    validate_node_id_input(&node_id).map_err(ffi_invalid_arg)?;
+    validate_node_id(&node_id).map_err(ffi_adapter_invalid_arg)?;
     let ep = get_endpoint(endpoint_handle)?;
     if let Some((_, sub)) = path_change_rxs().remove(&(endpoint_handle, node_id.clone())) {
         sub.notify.notify_waiters();
@@ -1071,10 +1013,10 @@ pub async fn raw_fetch(
     max_response_body_bytes: Option<f64>,
 ) -> napi::Result<JsFfiResponse> {
     let ep = get_endpoint(endpoint_handle)?;
-    validate_node_id_input(&node_id).map_err(ffi_invalid_arg)?;
-    validate_url_input(&url).map_err(ffi_invalid_arg)?;
-    validate_method_input(&method).map_err(ffi_invalid_arg)?;
-    validate_direct_addrs_input(&direct_addrs).map_err(ffi_invalid_arg)?;
+    validate_node_id(&node_id).map_err(ffi_adapter_invalid_arg)?;
+    validate_url(&url).map_err(ffi_adapter_invalid_arg)?;
+    validate_method(&method).map_err(ffi_adapter_invalid_arg)?;
+    validate_direct_addrs(&direct_addrs).map_err(ffi_adapter_invalid_arg)?;
 
     let pairs = validate_header_rows(headers).map_err(ffi_adapter_invalid_arg)?;
 
@@ -1348,8 +1290,8 @@ pub async fn session_connect(
     direct_addrs: Option<Vec<String>>,
 ) -> napi::Result<u64> {
     let ep = get_endpoint(endpoint_handle)?;
-    validate_node_id_input(&node_id).map_err(ffi_invalid_arg)?;
-    validate_direct_addrs_input(&direct_addrs).map_err(ffi_invalid_arg)?;
+    validate_node_id(&node_id).map_err(ffi_adapter_invalid_arg)?;
+    validate_direct_addrs(&direct_addrs).map_err(ffi_adapter_invalid_arg)?;
     let addrs =
         parse_direct_addrs(&direct_addrs).map_err(|e| napi::Error::new(Status::InvalidArg, e))?;
     let session = iroh_http_core::Session::connect(ep, &node_id, addrs.as_deref())
@@ -1609,22 +1551,22 @@ mod tests {
 
     #[test]
     fn validate_node_id_accepts_base32ish_input() {
-        let result = validate_node_id_input("abcdefghijklmnopqrstuvwxyz234567");
+        let result = validate_node_id("abcdefghijklmnopqrstuvwxyz234567");
         assert!(result.is_ok());
     }
 
     #[test]
     fn validate_node_id_rejects_invalid_chars() {
-        let result = validate_node_id_input("bad-node-id!");
-        assert!(matches!(result, Err(FfiError::InvalidNodeId)));
+        let result = validate_node_id("bad-node-id!");
+        assert!(matches!(result, Err(AdapterInputError::InvalidNodeId)));
     }
 
     #[test]
     fn validate_url_rejects_null_byte() {
-        let result = validate_url_input("httpi://peer/\x00x");
+        let result = validate_url("httpi://peer/\x00x");
         assert!(matches!(
             result,
-            Err(FfiError::InvalidEncoding { field: "url" })
+            Err(AdapterInputError::InvalidEncoding { field: "url" })
         ));
     }
 

--- a/packages/iroh-http-node/src/lib.rs
+++ b/packages/iroh-http-node/src/lib.rs
@@ -415,20 +415,17 @@ pub async fn create_endpoint(options: Option<JsNodeOptions>) -> napi::Result<JsE
                     || o.compression_level.is_some()
                 {
                     // ISS-020: validate compression level range before cast.
-                    if let Some(level) = o.compression_level {
-                        if level < 0 {
-                            return Err(napi::Error::new(
-                                Status::InvalidArg,
-                                format!("compressionLevel must be non-negative, got {level}"),
-                            ));
-                        }
-                    }
+                    let level = o
+                        .compression_level
+                        .map(iroh_http_adapter::validate_compression_level)
+                        .transpose()
+                        .map_err(ffi_adapter_invalid_arg)?;
                     Some(iroh_http_core::CompressionOptions {
                         min_body_bytes: o
                             .compression_min_body_bytes
                             .map(|v| v as usize)
                             .unwrap_or(iroh_http_core::CompressionOptions::DEFAULT_MIN_BODY_BYTES),
-                        level: o.compression_level.map(|v| v as u32),
+                        level,
                     })
                 } else {
                     None
@@ -1101,7 +1098,7 @@ pub struct JsServeOptions {
     pub max_request_body_decoded_bytes: Option<f64>,
     /// Maximum total QUIC connections the server will accept.  Default: unlimited.
     pub max_total_connections: Option<f64>,
-    /// Drain timeout in milliseconds after shutdown signal.  Default: 5000.
+    /// Drain timeout in milliseconds after shutdown signal.  Default: 30000.
     pub drain_timeout: Option<f64>,
     /// Enable load-shedding (reject with 503 when at capacity).
     pub load_shed: Option<bool>,

--- a/packages/iroh-http-node/src/lib.rs
+++ b/packages/iroh-http-node/src/lib.rs
@@ -67,8 +67,7 @@ use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64 as adapter_safe_f64_to_u64,
     safe_f64_to_usize as adapter_safe_f64_to_usize, send_undeliverable_rejection,
     validate_direct_addrs, validate_header_rows, validate_method, validate_node_id, validate_url,
-    AdapterInputError, MAX_BODY_BYTES as ADAPTER_MAX_BODY_BYTES,
-    MAX_TIMEOUT_MS as ADAPTER_MAX_TIMEOUT_MS,
+    AdapterInputError, MAX_BODY_BYTES, MAX_HEADER_BYTES, MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
 };
 
 struct PathSub {
@@ -90,10 +89,6 @@ fn path_change_rxs() -> &'static PathRxMap {
 const MAX_URL_LEN: usize = 8_192;
 #[cfg(feature = "discovery")]
 const MAX_MDNS_SERVICE_NAME_LEN: usize = 128;
-const MAX_TIMEOUT_MS: u64 = 300_000;
-const MAX_HEADER_BYTES: usize = 1_048_576;
-const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
-const MAX_TOTAL_CONNECTIONS: usize = 100_000;
 
 #[derive(Debug)]
 enum FfiError {
@@ -1028,12 +1023,12 @@ pub async fn raw_fetch(
     let addrs =
         parse_direct_addrs(&direct_addrs).map_err(|e| napi::Error::new(Status::InvalidArg, e))?;
     let timeout = timeout_ms
-        .map(|ms| adapter_safe_f64_to_u64(ms, "timeoutMs", ADAPTER_MAX_TIMEOUT_MS))
+        .map(|ms| adapter_safe_f64_to_u64(ms, "timeoutMs", MAX_TIMEOUT_MS))
         .transpose()
         .map_err(ffi_adapter_invalid_arg)?
         .map(std::time::Duration::from_millis);
     let max_resp = max_response_body_bytes
-        .map(|b| adapter_safe_f64_to_usize(b, "maxResponseBodyBytes", ADAPTER_MAX_BODY_BYTES))
+        .map(|b| adapter_safe_f64_to_usize(b, "maxResponseBodyBytes", MAX_BODY_BYTES))
         .transpose()
         .map_err(ffi_adapter_invalid_arg)?;
     let res = iroh_http_core::fetch(

--- a/packages/iroh-http-shared/src/serve.ts
+++ b/packages/iroh-http-shared/src/serve.ts
@@ -372,9 +372,17 @@ export function makeServe(
       .then(() => Promise.allSettled([...activePipes]))
       .then(() => {});
     // Reset guard when the loop finishes so serve() can be called again.
-    finished.finally(() => {
+    // Use `.then(onFulfilled, onRejected)` (not `.finally`) so the reset runs
+    // exactly one microtask after `finished` settles — matching the original
+    // `.finally` timing that rapid serve/stop/serve cycles depend on (#119) —
+    // while also handling a rejected `finished` (e.g. serve options rejected by
+    // the adapter's numeric caps) so it does not surface as an unhandled
+    // rejection through this internal bookkeeping chain. Callers still observe
+    // the rejection via the `finished` promise they hold.
+    const resetGuard = (): void => {
       serveRunning = false;
-    });
+    };
+    void finished.then(resetGuard, resetGuard);
 
     const doStop = (): void => {
       if (stopRequested) return;

--- a/packages/iroh-http-tauri/src/commands.rs
+++ b/packages/iroh-http-tauri/src/commands.rs
@@ -16,7 +16,8 @@ use crate::state;
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
     send_undeliverable_rejection, validate_direct_addrs, validate_header_rows, validate_method,
-    validate_node_id, validate_url, MAX_BODY_BYTES, MAX_TIMEOUT_MS,
+    validate_node_id, validate_url, MAX_BODY_BYTES, MAX_HEADER_BYTES, MAX_TIMEOUT_MS,
+    MAX_TOTAL_CONNECTIONS,
 };
 
 // ── Endpoint ──────────────────────────────────────────────────────────────────
@@ -28,7 +29,7 @@ use iroh_http_adapter::{
 #[serde(rename_all = "camelCase")]
 pub struct CreateEndpointArgs {
     pub key: Option<String>,
-    pub idle_timeout: Option<u64>,
+    pub idle_timeout: Option<f64>,
     pub relay_mode: Option<String>,
     pub relays: Option<Vec<String>>,
     pub bind_addrs: Option<Vec<String>>,
@@ -36,18 +37,18 @@ pub struct CreateEndpointArgs {
     pub dns_discovery_enabled: Option<bool>,
     pub channel_capacity: Option<usize>,
     pub max_chunk_size_bytes: Option<usize>,
-    pub handle_ttl: Option<u64>,
-    pub sweep_interval: Option<u64>,
+    pub handle_ttl: Option<f64>,
+    pub sweep_interval: Option<f64>,
     pub disable_networking: Option<bool>,
     pub proxy_url: Option<String>,
     pub proxy_from_env: Option<bool>,
     pub keylog: Option<bool>,
     pub compression_min_body_bytes: Option<usize>,
     pub compression_level: Option<u32>,
-    pub max_header_bytes: Option<usize>,
+    pub max_header_bytes: Option<f64>,
     /// TAURI-002: pool-tuning options previously ignored.
     pub max_pooled_connections: Option<usize>,
-    pub pool_idle_timeout_ms: Option<u64>,
+    pub pool_idle_timeout_ms: Option<f64>,
 }
 
 /// Info returned after a successful endpoint bind.
@@ -83,7 +84,11 @@ pub async fn create_endpoint<R: tauri::Runtime>(
                     relay_mode: a.relay_mode,
                     relays: a.relays.unwrap_or_default(),
                     bind_addrs: a.bind_addrs.unwrap_or_default(),
-                    idle_timeout_ms: a.idle_timeout,
+                    idle_timeout_ms: a
+                        .idle_timeout
+                        .map(|v| safe_f64_to_u64(v, "idleTimeout", MAX_TIMEOUT_MS))
+                        .transpose()
+                        .map_err(|e| e.to_json())?,
                     proxy_url: a.proxy_url,
                     proxy_from_env: a.proxy_from_env.unwrap_or(false),
                     disabled: a.disable_networking.unwrap_or(false),
@@ -94,18 +99,34 @@ pub async fn create_endpoint<R: tauri::Runtime>(
                 },
                 pool: PoolOptions {
                     max_connections: a.max_pooled_connections,
-                    idle_timeout_ms: a.pool_idle_timeout_ms,
+                    idle_timeout_ms: a
+                        .pool_idle_timeout_ms
+                        .map(|v| safe_f64_to_u64(v, "poolIdleTimeoutMs", MAX_TIMEOUT_MS))
+                        .transpose()
+                        .map_err(|e| e.to_json())?,
                 },
                 streaming: StreamingOptions {
                     channel_capacity: a.channel_capacity,
                     max_chunk_size_bytes: a.max_chunk_size_bytes,
                     drain_timeout_ms: None,
-                    handle_ttl_ms: a.handle_ttl,
-                    sweep_interval_ms: a.sweep_interval,
+                    handle_ttl_ms: a
+                        .handle_ttl
+                        .map(|v| safe_f64_to_u64(v, "handleTtl", MAX_TIMEOUT_MS))
+                        .transpose()
+                        .map_err(|e| e.to_json())?,
+                    sweep_interval_ms: a
+                        .sweep_interval
+                        .map(|v| safe_f64_to_u64(v, "sweepInterval", MAX_TIMEOUT_MS))
+                        .transpose()
+                        .map_err(|e| e.to_json())?,
                 },
                 capabilities: Vec::new(),
                 keylog: a.keylog.unwrap_or(false),
-                max_header_size: a.max_header_bytes,
+                max_header_size: a
+                    .max_header_bytes
+                    .map(|v| safe_f64_to_usize(v, "maxHeaderBytes", MAX_HEADER_BYTES))
+                    .transpose()
+                    .map_err(|e| e.to_json())?,
                 max_response_body_bytes: None,
                 compression: if a.compression_min_body_bytes.is_some()
                     || a.compression_level.is_some()
@@ -568,11 +589,11 @@ pub struct ServeArgs {
     pub endpoint_handle: u64,
     pub max_concurrency: Option<usize>,
     pub max_connections_per_peer: Option<usize>,
-    pub request_timeout: Option<u64>,
-    pub max_request_body_wire_bytes: Option<usize>,
-    pub max_request_body_decoded_bytes: Option<usize>,
-    pub max_total_connections: Option<usize>,
-    pub drain_timeout: Option<u64>,
+    pub request_timeout: Option<f64>,
+    pub max_request_body_wire_bytes: Option<f64>,
+    pub max_request_body_decoded_bytes: Option<f64>,
+    pub max_total_connections: Option<f64>,
+    pub drain_timeout: Option<f64>,
     pub load_shed: Option<bool>,
     pub decompress: Option<bool>,
 }
@@ -594,11 +615,31 @@ pub async fn serve(
     let serve_opts = iroh_http_core::ServeOptions {
         max_concurrency: args.max_concurrency,
         max_connections_per_peer: args.max_connections_per_peer,
-        request_timeout_ms: args.request_timeout,
-        max_request_body_wire_bytes: args.max_request_body_wire_bytes,
-        max_request_body_decoded_bytes: args.max_request_body_decoded_bytes,
-        max_total_connections: args.max_total_connections,
-        drain_timeout_ms: args.drain_timeout,
+        request_timeout_ms: args
+            .request_timeout
+            .map(|v| safe_f64_to_u64(v, "requestTimeout", MAX_TIMEOUT_MS))
+            .transpose()
+            .map_err(|e| e.to_json())?,
+        max_request_body_wire_bytes: args
+            .max_request_body_wire_bytes
+            .map(|v| safe_f64_to_usize(v, "maxRequestBodyWireBytes", MAX_BODY_BYTES))
+            .transpose()
+            .map_err(|e| e.to_json())?,
+        max_request_body_decoded_bytes: args
+            .max_request_body_decoded_bytes
+            .map(|v| safe_f64_to_usize(v, "maxRequestBodyDecodedBytes", MAX_BODY_BYTES))
+            .transpose()
+            .map_err(|e| e.to_json())?,
+        max_total_connections: args
+            .max_total_connections
+            .map(|v| safe_f64_to_usize(v, "maxTotalConnections", MAX_TOTAL_CONNECTIONS))
+            .transpose()
+            .map_err(|e| e.to_json())?,
+        drain_timeout_ms: args
+            .drain_timeout
+            .map(|v| safe_f64_to_u64(v, "drainTimeout", MAX_TIMEOUT_MS))
+            .transpose()
+            .map_err(|e| e.to_json())?,
         load_shed: args.load_shed,
         decompression: args.decompress,
     };

--- a/packages/iroh-http-tauri/src/commands.rs
+++ b/packages/iroh-http-tauri/src/commands.rs
@@ -15,9 +15,9 @@ use crate::state;
 
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
-    send_undeliverable_rejection, validate_direct_addrs, validate_header_rows, validate_method,
-    validate_node_id, validate_url, MAX_BODY_BYTES, MAX_HEADER_BYTES, MAX_TIMEOUT_MS,
-    MAX_TOTAL_CONNECTIONS,
+    send_undeliverable_rejection, validate_compression_level, validate_direct_addrs,
+    validate_header_rows, validate_method, validate_node_id, validate_url, MAX_BODY_BYTES,
+    MAX_HEADER_BYTES, MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
 };
 
 // ── Endpoint ──────────────────────────────────────────────────────────────────
@@ -44,7 +44,7 @@ pub struct CreateEndpointArgs {
     pub proxy_from_env: Option<bool>,
     pub keylog: Option<bool>,
     pub compression_min_body_bytes: Option<usize>,
-    pub compression_level: Option<u32>,
+    pub compression_level: Option<i32>,
     pub max_header_bytes: Option<f64>,
     /// TAURI-002: pool-tuning options previously ignored.
     pub max_pooled_connections: Option<usize>,
@@ -131,11 +131,17 @@ pub async fn create_endpoint<R: tauri::Runtime>(
                 compression: if a.compression_min_body_bytes.is_some()
                     || a.compression_level.is_some()
                 {
+                    // ISS-020: validate compression level range before cast.
+                    let level = a
+                        .compression_level
+                        .map(validate_compression_level)
+                        .transpose()
+                        .map_err(|e| e.to_json())?;
                     Some(iroh_http_core::CompressionOptions {
                         min_body_bytes: a
                             .compression_min_body_bytes
                             .unwrap_or(iroh_http_core::CompressionOptions::DEFAULT_MIN_BODY_BYTES),
-                        level: a.compression_level,
+                        level,
                     })
                 } else {
                     None

--- a/packages/iroh-http-tauri/src/commands.rs
+++ b/packages/iroh-http-tauri/src/commands.rs
@@ -15,7 +15,8 @@ use crate::state;
 
 use iroh_http_adapter::{
     core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
-    send_undeliverable_rejection, validate_header_rows, MAX_BODY_BYTES, MAX_TIMEOUT_MS,
+    send_undeliverable_rejection, validate_direct_addrs, validate_header_rows, validate_method,
+    validate_node_id, validate_url, MAX_BODY_BYTES, MAX_TIMEOUT_MS,
 };
 
 // ── Endpoint ──────────────────────────────────────────────────────────────────
@@ -497,6 +498,10 @@ pub async fn fetch(args: RawFetchArgs) -> Result<FfiResponsePayload, String> {
     })?;
 
     let pairs = validate_header_rows(args.headers).map_err(|e| e.to_json())?;
+    validate_node_id(&args.node_id).map_err(|e| e.to_json())?;
+    validate_url(&args.url).map_err(|e| e.to_json())?;
+    validate_method(&args.method).map_err(|e| e.to_json())?;
+    validate_direct_addrs(&args.direct_addrs).map_err(|e| e.to_json())?;
 
     let req_body_reader = args
         .req_body_handle

--- a/tests/suites/adapter-validation.mjs
+++ b/tests/suites/adapter-validation.mjs
@@ -81,6 +81,38 @@ export function adapterValidationTests({
     }
   });
 
+  test("adapter validation rejects invalid fetch inputs", async () => {
+    const node = await createNode({ disableNetworking: true });
+    try {
+      const { id } = await node.addr();
+      const validUrl = `httpi://${id}/validation`;
+      // Invalid node id: digit "0" is outside the base32 alphabet (a-z, 2-7).
+      await assertThrows(async () => {
+        await node.fetch("httpi://peer0/validation");
+      }, "invalid node id");
+      // Over-long method (max 32 bytes).
+      await assertThrows(async () => {
+        await node.fetch(validUrl, { method: "M".repeat(33) });
+      }, "over-long method");
+      // Too many direct addresses (max 32).
+      await assertThrows(async () => {
+        await node.fetch(validUrl, {
+          directAddrs: Array.from({ length: 33 }, () => "127.0.0.1:1"),
+        });
+      }, "too many direct addrs");
+      // Over-long direct address (max 256 bytes).
+      await assertThrows(async () => {
+        await node.fetch(validUrl, { directAddrs: ["1".repeat(257)] });
+      }, "over-long direct addr");
+      // Over-long URL (max 8192 bytes).
+      await assertThrows(async () => {
+        await node.fetch(`httpi://${id}/${"p".repeat(8300)}`);
+      }, "over-long url");
+    } finally {
+      await node.close();
+    }
+  });
+
   test("adapter validation accepts valid fetch headers and numeric knobs", async () => {
     const node = await createNode({ disableNetworking: true });
     let handle;

--- a/tests/suites/adapter-validation.mjs
+++ b/tests/suites/adapter-validation.mjs
@@ -149,6 +149,15 @@ export function adapterValidationTests({
     }
   });
 
+  test("adapter validation rejects negative compression level", async () => {
+    await assertThrows(async () => {
+      await createNode({
+        disableNetworking: true,
+        compression: { level: -1 },
+      });
+    }, "compressionLevel -1");
+  });
+
   test("adapter validation accepts valid fetch headers and numeric knobs", async () => {
     const node = await createNode({ disableNetworking: true });
     let handle;

--- a/tests/suites/adapter-validation.mjs
+++ b/tests/suites/adapter-validation.mjs
@@ -113,6 +113,42 @@ export function adapterValidationTests({
     }
   });
 
+  test("adapter validation rejects invalid endpoint numeric options", async () => {
+    // Over-cap values can only be rejected by the shared adapter cap logic
+    // (JS has no knowledge of the cap), so this exercises the Rust boundary
+    // identically on every runtime.
+    await assertThrows(async () => {
+      await createNode({
+        disableNetworking: true,
+        limits: { maxHeaderBytes: 2_000_000 },
+      });
+    }, "maxHeaderBytes over cap");
+    await assertThrows(async () => {
+      await createNode({
+        disableNetworking: true,
+        connections: { idleTimeoutMs: 400_000 },
+      });
+    }, "idleTimeoutMs over cap");
+  });
+
+  test("adapter validation rejects invalid serve numeric caps", async () => {
+    const node = await createNode({ disableNetworking: true });
+    try {
+      // Over-cap value is only rejectable by the shared adapter cap logic, so
+      // this exercises the serve-side coercion path identically on every
+      // runtime. The reject surfaces through the serve handle's `finished`.
+      await assertThrows(async () => {
+        const handle = node.serve(
+          { maxTotalConnections: 200_000 },
+          () => new Response("x"),
+        );
+        if (handle && handle.finished) await handle.finished;
+      }, "maxTotalConnections over cap");
+    } finally {
+      await node.close();
+    }
+  });
+
   test("adapter validation accepts valid fetch headers and numeric knobs", async () => {
     const node = await createNode({ disableNetworking: true });
     let handle;


### PR DESCRIPTION
## Summary

Consolidates the hand-rolled, divergent fetch/serve option validation, coercion, and numeric caps from the three Rust adapter decode sites (Node napi, Deno FFI dispatch, Tauri commands) into the shared `iroh-http-adapter` crate, so every runtime fails closed identically. Builds on the already-merged tracer-bullet slice (`validate_header_rows`, `safe_f64_*`, `MAX_TIMEOUT_MS`, `MAX_BODY_BYTES`).

This is the security-consolidation portion of the epic. The `coerce_fetch_options` / `coerce_serve_options` seam refactor (Slice D) is intentionally **not** in this PR.

## Commits

- **`5e5d8c2` — fetch input validation (Item 2, High).** Lifts node-id / URL / method / direct-addrs validation into the adapter (`validate_node_id`, `validate_url`, `validate_method`, `validate_direct_addrs` + `MAX_*` bounds and `INVALID_NODE_ID` / `INVALID_URL` codes). Node drops its local `validate_*_input` helpers, `FfiError::Invalid{NodeId,Url}` variants and duplicate consts; Deno `raw_fetch_impl` and Tauri `fetch` gain the four validators (previously **none** — they did no fetch input validation at all).
- **`83614bc` — serve/endpoint numeric caps (Item 5, High).** Adds `MAX_TOTAL_CONNECTIONS` and `MAX_HEADER_BYTES` to the adapter and routes every serve/endpoint numeric knob on all three adapters through the shared `safe_f64_*` coercion (`idleTimeout`, `poolIdleTimeoutMs`, `handleTtl`, `sweepInterval`, `maxHeaderBytes`, `requestTimeout`, `maxRequestBody{Wire,Decoded}Bytes`, `maxTotalConnections`, `drainTimeout`). Deno/Tauri payload fields change to `f64` so the same coercion yields byte-identical rejects/defaults. Also stops the shared `serve()` bookkeeping chain from surfacing a rejected `finished` as an unhandled rejection, while preserving the exact `serveRunning`-reset timing that rapid serve/stop cycles depend on (#119).
- **`2a97728` — compressionLevel + drainTimeout doc (Items 6 & 7, Low).** Adds `validate_compression_level` (single `< 0` reject) and wires all three adapters; Tauri's `compressionLevel` field changes `u32 → i32` so it fails closed like Node/Deno instead of via a generic serde error. Corrects the Node `drainTimeout` doc (and generated `index.d.ts`): core default is `30000` ms, not `5000`.

## Divergence-table items closed

- ✅ **Item 2 (High)** — fetch input validation now shared and applied on Node/Deno/Tauri.
- ✅ **Item 5 (High)** — serve-side numeric caps (`MAX_TOTAL_CONNECTIONS`, `MAX_HEADER_BYTES`) applied uniformly.
- ✅ **Item 6 (Low)** — `compressionLevel` type + validation unified.
- ✅ **Item 7 (Low)** — `drainTimeout` doc drift corrected.

(Item 4 — respond header rows — was already done on all three adapters. Item 8 — `maxServeErrors` — is moot, removed in #278.)

## Conformance

The cross-runtime conformance suite (`tests/suites/adapter-validation.mjs`, shared by the Node/Deno/Tauri runners) asserts **identical rejects and defaults** across runtimes for: malformed header rows, invalid fetch numeric knobs, invalid fetch inputs (node-id/url/method/direct-addrs), invalid endpoint numeric options, invalid serve numeric caps, negative compression level, plus valid pass-through and default-knob acceptance. Endpoint/serve cap cases use over-cap values that only the shared adapter cap logic can reject, so they exercise the Rust boundary on every runtime. Verified green on Node and Deno; `npm run ci` passes end-to-end.

No fetch/serve setup-latency regression (validation is a handful of bounds checks on the existing decode path).

Refs #289