### PR TITLE
refactor(adapter): consolidate adapter coercion behind coerce_* seam (#289)

### DIFF
--- a/crates/iroh-http-adapter/src/lib.rs
+++ b/crates/iroh-http-adapter/src/lib.rs
@@ -259,6 +259,188 @@ pub fn validate_compression_level(level: i32) -> Result<u32, AdapterInputError> 
     Ok(level as u32)
 }
 
+/// Raw fetch inputs decoded from a platform FFI call, prior to validation.
+///
+/// This is the shape every adapter (Node napi, Deno FFI, Tauri command) hands
+/// to [`coerce_fetch_options`]. Numeric knobs arrive as `f64` because that is
+/// how JS numbers cross each boundary.
+#[derive(Debug, Clone)]
+pub struct RawFetchOptions {
+    pub node_id: String,
+    pub url: String,
+    pub method: String,
+    pub direct_addrs: Option<Vec<String>>,
+    pub headers: Vec<Vec<String>>,
+    pub timeout_ms: Option<f64>,
+    pub max_response_body_bytes: Option<f64>,
+}
+
+/// Fully validated and coerced fetch inputs produced by [`coerce_fetch_options`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchOptions {
+    pub node_id: String,
+    pub url: String,
+    pub method: String,
+    pub direct_addrs: Option<Vec<String>>,
+    pub headers: Vec<(String, String)>,
+    pub timeout_ms: Option<u64>,
+    pub max_response_body_bytes: Option<usize>,
+}
+
+/// Validate and coerce all fetch inputs behind a single seam.
+///
+/// Composes the individual `validate_*` / `safe_f64_*` helpers so every adapter
+/// applies identical boundary checks, in identical order, and receives a single
+/// validated struct. The validation order (node id, url, method, direct addrs,
+/// headers, then the numeric knobs) matches the Node reference implementation.
+pub fn coerce_fetch_options(raw: RawFetchOptions) -> Result<FetchOptions, AdapterInputError> {
+    validate_node_id(&raw.node_id)?;
+    validate_url(&raw.url)?;
+    validate_method(&raw.method)?;
+    validate_direct_addrs(&raw.direct_addrs)?;
+    let headers = validate_header_rows(raw.headers)?;
+    let timeout_ms = raw
+        .timeout_ms
+        .map(|ms| safe_f64_to_u64(ms, "timeoutMs", MAX_TIMEOUT_MS))
+        .transpose()?;
+    let max_response_body_bytes = raw
+        .max_response_body_bytes
+        .map(|b| safe_f64_to_usize(b, "maxResponseBodyBytes", MAX_BODY_BYTES))
+        .transpose()?;
+    Ok(FetchOptions {
+        node_id: raw.node_id,
+        url: raw.url,
+        method: raw.method,
+        direct_addrs: raw.direct_addrs,
+        headers,
+        timeout_ms,
+        max_response_body_bytes,
+    })
+}
+
+/// Raw endpoint (`createNode`/bind) numeric knobs decoded from a platform FFI
+/// call, prior to validation.
+#[derive(Debug, Clone, Default)]
+pub struct RawEndpointOptions {
+    pub idle_timeout_ms: Option<f64>,
+    pub pool_idle_timeout_ms: Option<f64>,
+    pub handle_ttl_ms: Option<f64>,
+    pub sweep_interval_ms: Option<f64>,
+    pub max_header_bytes: Option<f64>,
+    pub compression_level: Option<i32>,
+}
+
+/// Fully validated and coerced endpoint numeric knobs produced by
+/// [`coerce_endpoint_options`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EndpointOptions {
+    pub idle_timeout_ms: Option<u64>,
+    pub pool_idle_timeout_ms: Option<u64>,
+    pub handle_ttl_ms: Option<u64>,
+    pub sweep_interval_ms: Option<u64>,
+    pub max_header_bytes: Option<usize>,
+    pub compression_level: Option<u32>,
+}
+
+/// Validate and coerce the endpoint-bind numeric knobs behind a single seam.
+///
+/// Field order matches the Node reference implementation: idle timeout, pool
+/// idle timeout, handle TTL, sweep interval, max header bytes, compression
+/// level.
+pub fn coerce_endpoint_options(
+    raw: RawEndpointOptions,
+) -> Result<EndpointOptions, AdapterInputError> {
+    let idle_timeout_ms = raw
+        .idle_timeout_ms
+        .map(|v| safe_f64_to_u64(v, "idleTimeout", MAX_TIMEOUT_MS))
+        .transpose()?;
+    let pool_idle_timeout_ms = raw
+        .pool_idle_timeout_ms
+        .map(|v| safe_f64_to_u64(v, "poolIdleTimeoutMs", MAX_TIMEOUT_MS))
+        .transpose()?;
+    let handle_ttl_ms = raw
+        .handle_ttl_ms
+        .map(|v| safe_f64_to_u64(v, "handleTtl", MAX_TIMEOUT_MS))
+        .transpose()?;
+    let sweep_interval_ms = raw
+        .sweep_interval_ms
+        .map(|v| safe_f64_to_u64(v, "sweepInterval", MAX_TIMEOUT_MS))
+        .transpose()?;
+    let max_header_bytes = raw
+        .max_header_bytes
+        .map(|v| safe_f64_to_usize(v, "maxHeaderBytes", MAX_HEADER_BYTES))
+        .transpose()?;
+    let compression_level = raw
+        .compression_level
+        .map(validate_compression_level)
+        .transpose()?;
+    Ok(EndpointOptions {
+        idle_timeout_ms,
+        pool_idle_timeout_ms,
+        handle_ttl_ms,
+        sweep_interval_ms,
+        max_header_bytes,
+        compression_level,
+    })
+}
+
+/// Raw serve numeric knobs decoded from a platform FFI call, prior to
+/// validation.
+#[derive(Debug, Clone, Default)]
+pub struct RawServeOptions {
+    pub request_timeout_ms: Option<f64>,
+    pub max_request_body_wire_bytes: Option<f64>,
+    pub max_request_body_decoded_bytes: Option<f64>,
+    pub max_total_connections: Option<f64>,
+    pub drain_timeout_ms: Option<f64>,
+}
+
+/// Fully validated and coerced serve numeric knobs produced by
+/// [`coerce_serve_options`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ServeOptions {
+    pub request_timeout_ms: Option<u64>,
+    pub max_request_body_wire_bytes: Option<usize>,
+    pub max_request_body_decoded_bytes: Option<usize>,
+    pub max_total_connections: Option<usize>,
+    pub drain_timeout_ms: Option<u64>,
+}
+
+/// Validate and coerce the serve numeric knobs behind a single seam.
+///
+/// Field order matches the Node reference implementation: request timeout,
+/// max request body wire bytes, max request body decoded bytes, max total
+/// connections, drain timeout.
+pub fn coerce_serve_options(raw: RawServeOptions) -> Result<ServeOptions, AdapterInputError> {
+    let request_timeout_ms = raw
+        .request_timeout_ms
+        .map(|v| safe_f64_to_u64(v, "requestTimeout", MAX_TIMEOUT_MS))
+        .transpose()?;
+    let max_request_body_wire_bytes = raw
+        .max_request_body_wire_bytes
+        .map(|v| safe_f64_to_usize(v, "maxRequestBodyWireBytes", MAX_BODY_BYTES))
+        .transpose()?;
+    let max_request_body_decoded_bytes = raw
+        .max_request_body_decoded_bytes
+        .map(|v| safe_f64_to_usize(v, "maxRequestBodyDecodedBytes", MAX_BODY_BYTES))
+        .transpose()?;
+    let max_total_connections = raw
+        .max_total_connections
+        .map(|v| safe_f64_to_usize(v, "maxTotalConnections", MAX_TOTAL_CONNECTIONS))
+        .transpose()?;
+    let drain_timeout_ms = raw
+        .drain_timeout_ms
+        .map(|v| safe_f64_to_u64(v, "drainTimeout", MAX_TIMEOUT_MS))
+        .transpose()?;
+    Ok(ServeOptions {
+        request_timeout_ms,
+        max_request_body_wire_bytes,
+        max_request_body_decoded_bytes,
+        max_total_connections,
+        drain_timeout_ms,
+    })
+}
+
 fn validate_bounded_string(
     field: &'static str,
     value: &str,
@@ -562,6 +744,132 @@ mod tests {
             validate_compression_level(-1),
             Err(AdapterInputError::InvalidArgument {
                 field: "compressionLevel",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn coerce_fetch_options_validates_and_coerces() {
+        let ok = coerce_fetch_options(RawFetchOptions {
+            node_id: "abcdefghijklmnopqrstuvwxyz234567".to_string(),
+            url: "httpi://peer/path".to_string(),
+            method: "GET".to_string(),
+            direct_addrs: Some(vec!["127.0.0.1:1234".to_string()]),
+            headers: vec![vec!["x".to_string(), "y".to_string()]],
+            timeout_ms: Some(1000.0),
+            max_response_body_bytes: Some(2048.0),
+        })
+        .expect("valid fetch options");
+        assert_eq!(ok.headers, vec![("x".to_string(), "y".to_string())]);
+        assert_eq!(ok.timeout_ms, Some(1000));
+        assert_eq!(ok.max_response_body_bytes, Some(2048));
+
+        // Invalid node id is rejected.
+        let bad_node = coerce_fetch_options(RawFetchOptions {
+            node_id: "bad-node-id!".to_string(),
+            url: "httpi://peer/".to_string(),
+            method: "GET".to_string(),
+            direct_addrs: None,
+            headers: vec![],
+            timeout_ms: None,
+            max_response_body_bytes: None,
+        });
+        assert!(matches!(bad_node, Err(AdapterInputError::InvalidNodeId)));
+
+        // Over-cap timeout is rejected with the timeoutMs field.
+        let bad_timeout = coerce_fetch_options(RawFetchOptions {
+            node_id: "aaaa".to_string(),
+            url: "httpi://peer/".to_string(),
+            method: "GET".to_string(),
+            direct_addrs: None,
+            headers: vec![],
+            timeout_ms: Some((MAX_TIMEOUT_MS + 1) as f64),
+            max_response_body_bytes: None,
+        });
+        assert!(matches!(
+            bad_timeout,
+            Err(AdapterInputError::InvalidArgument {
+                field: "timeoutMs",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn coerce_endpoint_options_validates_and_coerces() {
+        let ok = coerce_endpoint_options(RawEndpointOptions {
+            idle_timeout_ms: Some(1000.0),
+            pool_idle_timeout_ms: Some(2000.0),
+            handle_ttl_ms: Some(3000.0),
+            sweep_interval_ms: Some(4000.0),
+            max_header_bytes: Some(65536.0),
+            compression_level: Some(9),
+        })
+        .expect("valid endpoint options");
+        assert_eq!(ok.idle_timeout_ms, Some(1000));
+        assert_eq!(ok.max_header_bytes, Some(65536));
+        assert_eq!(ok.compression_level, Some(9));
+
+        assert_eq!(
+            coerce_endpoint_options(RawEndpointOptions::default()),
+            Ok(EndpointOptions::default())
+        );
+
+        // Over-cap max header bytes is rejected.
+        let bad = coerce_endpoint_options(RawEndpointOptions {
+            max_header_bytes: Some((MAX_HEADER_BYTES + 1) as f64),
+            ..Default::default()
+        });
+        assert!(matches!(
+            bad,
+            Err(AdapterInputError::InvalidArgument {
+                field: "maxHeaderBytes",
+                ..
+            })
+        ));
+
+        // Negative compression level is rejected.
+        let bad_level = coerce_endpoint_options(RawEndpointOptions {
+            compression_level: Some(-1),
+            ..Default::default()
+        });
+        assert!(matches!(
+            bad_level,
+            Err(AdapterInputError::InvalidArgument {
+                field: "compressionLevel",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn coerce_serve_options_validates_and_coerces() {
+        let ok = coerce_serve_options(RawServeOptions {
+            request_timeout_ms: Some(1000.0),
+            max_request_body_wire_bytes: Some(2048.0),
+            max_request_body_decoded_bytes: Some(4096.0),
+            max_total_connections: Some(1000.0),
+            drain_timeout_ms: Some(5000.0),
+        })
+        .expect("valid serve options");
+        assert_eq!(ok.request_timeout_ms, Some(1000));
+        assert_eq!(ok.max_total_connections, Some(1000));
+
+        assert_eq!(
+            coerce_serve_options(RawServeOptions::default()),
+            Ok(ServeOptions::default())
+        );
+
+        // Over-cap total connections is rejected.
+        let bad = coerce_serve_options(RawServeOptions {
+            max_total_connections: Some((MAX_TOTAL_CONNECTIONS + 1) as f64),
+            ..Default::default()
+        });
+        assert!(matches!(
+            bad,
+            Err(AdapterInputError::InvalidArgument {
+                field: "maxTotalConnections",
                 ..
             })
         ));

--- a/packages/iroh-http-deno/src/dispatch.rs
+++ b/packages/iroh-http-deno/src/dispatch.rs
@@ -69,10 +69,9 @@ fn insert_endpoint(ep: IrohEndpoint) -> u64 {
 }
 
 use iroh_http_adapter::{
-    core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
-    send_undeliverable_rejection, validate_compression_level, validate_direct_addrs,
-    validate_header_rows, validate_method, validate_node_id, validate_url, AdapterInputError,
-    MAX_BODY_BYTES, MAX_HEADER_BYTES, MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
+    coerce_endpoint_options, coerce_fetch_options, coerce_serve_options, core_error_to_json,
+    format_error_json, send_undeliverable_rejection, validate_header_rows, AdapterInputError,
+    RawEndpointOptions, RawFetchOptions, RawServeOptions,
 };
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -95,24 +94,6 @@ fn err_core(e: iroh_http_core::CoreError) -> Value {
 
 fn err_adapter(e: AdapterInputError) -> Value {
     err_code(e.code(), e.message())
-}
-
-/// Coerce an optional f64 knob to a capped `u64`, matching the adapter contract.
-fn coerce_opt_u64(
-    value: Option<f64>,
-    field: &'static str,
-    max: u64,
-) -> Result<Option<u64>, AdapterInputError> {
-    value.map(|v| safe_f64_to_u64(v, field, max)).transpose()
-}
-
-/// Coerce an optional f64 knob to a capped `usize`, matching the adapter contract.
-fn coerce_opt_usize(
-    value: Option<f64>,
-    field: &'static str,
-    max: usize,
-) -> Result<Option<usize>, AdapterInputError> {
-    value.map(|v| safe_f64_to_usize(v, field, max)).transpose()
 }
 
 fn deliver_request_to_queue(handle: u64, ep: &IrohEndpoint, payload: RequestPayload) {
@@ -320,32 +301,17 @@ async fn create_endpoint(p: Value) -> Value {
         }
     };
 
-    let idle_timeout_ms = match coerce_opt_u64(args.idle_timeout, "idleTimeout", MAX_TIMEOUT_MS) {
+    let endpoint = match coerce_endpoint_options(RawEndpointOptions {
+        idle_timeout_ms: args.idle_timeout,
+        pool_idle_timeout_ms: args.pool_idle_timeout_ms,
+        handle_ttl_ms: args.handle_ttl,
+        sweep_interval_ms: args.sweep_interval,
+        max_header_bytes: args.max_header_bytes,
+        compression_level: args.compression_level,
+    }) {
         Ok(v) => v,
         Err(e) => return err_adapter(e),
     };
-    let pool_idle_timeout_ms = match coerce_opt_u64(
-        args.pool_idle_timeout_ms,
-        "poolIdleTimeoutMs",
-        MAX_TIMEOUT_MS,
-    ) {
-        Ok(v) => v,
-        Err(e) => return err_adapter(e),
-    };
-    let handle_ttl_ms = match coerce_opt_u64(args.handle_ttl, "handleTtl", MAX_TIMEOUT_MS) {
-        Ok(v) => v,
-        Err(e) => return err_adapter(e),
-    };
-    let sweep_interval_ms =
-        match coerce_opt_u64(args.sweep_interval, "sweepInterval", MAX_TIMEOUT_MS) {
-            Ok(v) => v,
-            Err(e) => return err_adapter(e),
-        };
-    let max_header_size =
-        match coerce_opt_usize(args.max_header_bytes, "maxHeaderBytes", MAX_HEADER_BYTES) {
-            Ok(v) => v,
-            Err(e) => return err_adapter(e),
-        };
 
     let opts = NodeOptions {
         key,
@@ -353,7 +319,7 @@ async fn create_endpoint(p: Value) -> Value {
             relay_mode: args.relay_mode,
             relays: args.relays.unwrap_or_default(),
             bind_addrs: args.bind_addrs.unwrap_or_default(),
-            idle_timeout_ms,
+            idle_timeout_ms: endpoint.idle_timeout_ms,
             proxy_url: args.proxy_url,
             proxy_from_env: args.proxy_from_env.unwrap_or(false),
             disabled: args.disable_networking.unwrap_or(false),
@@ -364,36 +330,27 @@ async fn create_endpoint(p: Value) -> Value {
         },
         pool: PoolOptions {
             max_connections: args.max_pooled_connections,
-            idle_timeout_ms: pool_idle_timeout_ms,
+            idle_timeout_ms: endpoint.pool_idle_timeout_ms,
         },
         streaming: StreamingOptions {
             channel_capacity: args.channel_capacity,
             max_chunk_size_bytes: args.max_chunk_size_bytes,
             drain_timeout_ms: None,
-            handle_ttl_ms,
-            sweep_interval_ms,
+            handle_ttl_ms: endpoint.handle_ttl_ms,
+            sweep_interval_ms: endpoint.sweep_interval_ms,
         },
         capabilities: Vec::new(),
         keylog: args.keylog.unwrap_or(false),
-        max_header_size,
+        max_header_size: endpoint.max_header_bytes,
         max_response_body_bytes: None,
         compression: if args.compression_min_body_bytes.is_some()
             || args.compression_level.is_some()
         {
-            // ISS-020: validate compression level range before cast.
-            let level = match args
-                .compression_level
-                .map(validate_compression_level)
-                .transpose()
-            {
-                Ok(v) => v,
-                Err(e) => return err_adapter(e),
-            };
             Some(iroh_http_core::CompressionOptions {
                 min_body_bytes: args
                     .compression_min_body_bytes
                     .unwrap_or(iroh_http_core::CompressionOptions::DEFAULT_MIN_BODY_BYTES),
-                level,
+                level: endpoint.compression_level,
             })
         } else {
             None
@@ -696,46 +653,28 @@ async fn raw_fetch_impl(args: RawFetchPayload) -> Value {
             )
         }
     };
-    let pairs = match validate_header_rows(args.headers) {
-        Ok(pairs) => pairs,
+    let opts = match coerce_fetch_options(RawFetchOptions {
+        node_id: args.node_id,
+        url: args.url,
+        method: args.method,
+        direct_addrs: args.direct_addrs,
+        headers: args.headers,
+        timeout_ms: args.timeout_ms,
+        max_response_body_bytes: args.max_response_body_bytes,
+    }) {
+        Ok(v) => v,
         Err(e) => return err_adapter(e),
     };
-    if let Err(e) = validate_node_id(&args.node_id) {
-        return err_adapter(e);
-    }
-    if let Err(e) = validate_url(&args.url) {
-        return err_adapter(e);
-    }
-    if let Err(e) = validate_method(&args.method) {
-        return err_adapter(e);
-    }
-    if let Err(e) = validate_direct_addrs(&args.direct_addrs) {
-        return err_adapter(e);
-    }
     let reader = args
         .req_body_handle
         .and_then(|h| ep.handles().claim_pending_reader(h));
-    let addrs = match parse_direct_addrs(&args.direct_addrs) {
+    let addrs = match parse_direct_addrs(&opts.direct_addrs) {
         Ok(a) => a,
         Err(e) => return err(e),
     };
 
-    let timeout = match args
-        .timeout_ms
-        .map(|ms| safe_f64_to_u64(ms, "timeoutMs", MAX_TIMEOUT_MS))
-        .transpose()
-    {
-        Ok(timeout) => timeout.map(std::time::Duration::from_millis),
-        Err(e) => return err_adapter(e),
-    };
-    let max_response_body_bytes = match args
-        .max_response_body_bytes
-        .map(|b| safe_f64_to_usize(b, "maxResponseBodyBytes", MAX_BODY_BYTES))
-        .transpose()
-    {
-        Ok(bytes) => bytes,
-        Err(e) => return err_adapter(e),
-    };
+    let timeout = opts.timeout_ms.map(std::time::Duration::from_millis);
+    let max_response_body_bytes = opts.max_response_body_bytes;
 
     // #126: If the caller didn't supply a fetch token, allocate one
     // internally so the JS side doesn't need a separate FFI round-trip.
@@ -746,10 +685,10 @@ async fn raw_fetch_impl(args: RawFetchPayload) -> Value {
 
     match iroh_http_core::fetch(
         &ep,
-        &args.node_id,
-        &args.url,
-        &args.method,
-        &pairs,
+        &opts.node_id,
+        &opts.url,
+        &opts.method,
+        &opts.headers,
         reader,
         fetch_token,
         addrs.as_deref(),
@@ -791,51 +730,24 @@ async fn serve_start(p: Value) -> Value {
     };
 
     // Parse optional serve options from payload.
-    let request_timeout_ms = match coerce_opt_u64(
-        p["requestTimeout"].as_f64(),
-        "requestTimeout",
-        MAX_TIMEOUT_MS,
-    ) {
+    let serve = match coerce_serve_options(RawServeOptions {
+        request_timeout_ms: p["requestTimeout"].as_f64(),
+        max_request_body_wire_bytes: p["maxRequestBodyWireBytes"].as_f64(),
+        max_request_body_decoded_bytes: p["maxRequestBodyDecodedBytes"].as_f64(),
+        max_total_connections: p["maxTotalConnections"].as_f64(),
+        drain_timeout_ms: p["drainTimeout"].as_f64(),
+    }) {
         Ok(v) => v,
         Err(e) => return err_adapter(e),
     };
-    let max_request_body_wire_bytes = match coerce_opt_usize(
-        p["maxRequestBodyWireBytes"].as_f64(),
-        "maxRequestBodyWireBytes",
-        MAX_BODY_BYTES,
-    ) {
-        Ok(v) => v,
-        Err(e) => return err_adapter(e),
-    };
-    let max_request_body_decoded_bytes = match coerce_opt_usize(
-        p["maxRequestBodyDecodedBytes"].as_f64(),
-        "maxRequestBodyDecodedBytes",
-        MAX_BODY_BYTES,
-    ) {
-        Ok(v) => v,
-        Err(e) => return err_adapter(e),
-    };
-    let max_total_connections = match coerce_opt_usize(
-        p["maxTotalConnections"].as_f64(),
-        "maxTotalConnections",
-        MAX_TOTAL_CONNECTIONS,
-    ) {
-        Ok(v) => v,
-        Err(e) => return err_adapter(e),
-    };
-    let drain_timeout_ms =
-        match coerce_opt_u64(p["drainTimeout"].as_f64(), "drainTimeout", MAX_TIMEOUT_MS) {
-            Ok(v) => v,
-            Err(e) => return err_adapter(e),
-        };
     let serve_opts = iroh_http_core::ServeOptions {
         max_concurrency: p["maxConcurrency"].as_u64().map(|v| v as usize),
         max_connections_per_peer: p["maxConnectionsPerPeer"].as_u64().map(|v| v as usize),
-        request_timeout_ms,
-        max_request_body_wire_bytes,
-        max_request_body_decoded_bytes,
-        max_total_connections,
-        drain_timeout_ms,
+        request_timeout_ms: serve.request_timeout_ms,
+        max_request_body_wire_bytes: serve.max_request_body_wire_bytes,
+        max_request_body_decoded_bytes: serve.max_request_body_decoded_bytes,
+        max_total_connections: serve.max_total_connections,
+        drain_timeout_ms: serve.drain_timeout_ms,
         load_shed: p["loadShed"].as_bool(),
         decompression: p["decompress"].as_bool(),
     };

--- a/packages/iroh-http-node/src/lib.rs
+++ b/packages/iroh-http-node/src/lib.rs
@@ -64,10 +64,9 @@ use slab::Slab;
 use tokio::sync::Mutex as TokioMutex;
 
 use iroh_http_adapter::{
-    core_error_to_json, format_error_json, safe_f64_to_u64 as adapter_safe_f64_to_u64,
-    safe_f64_to_usize as adapter_safe_f64_to_usize, send_undeliverable_rejection,
-    validate_direct_addrs, validate_header_rows, validate_method, validate_node_id, validate_url,
-    AdapterInputError, MAX_BODY_BYTES, MAX_HEADER_BYTES, MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
+    coerce_endpoint_options, coerce_fetch_options, coerce_serve_options, core_error_to_json,
+    format_error_json, send_undeliverable_rejection, validate_direct_addrs, validate_header_rows,
+    validate_node_id, AdapterInputError, RawEndpointOptions, RawFetchOptions, RawServeOptions,
 };
 
 struct PathSub {
@@ -245,51 +244,6 @@ fn advertise_slab() -> &'static Mutex<Slab<iroh_http_discovery::AdvertiseSession
 
 // ── Endpoint lifecycle ────────────────────────────────────────────────────────
 
-/// Validate and convert an f64 option to a non-negative integer type.
-fn safe_f64_to_u64(value: f64, field: &'static str, max: u64) -> napi::Result<u64> {
-    if value.is_nan() || value.is_infinite() || value < 0.0 {
-        return Err(ffi_invalid_arg(FfiError::InvalidArgument {
-            field,
-            reason: format!("expected a non-negative finite number, got {value}"),
-        }));
-    }
-    if value.fract() != 0.0 {
-        return Err(ffi_invalid_arg(FfiError::InvalidArgument {
-            field,
-            reason: "must be an integer".to_string(),
-        }));
-    }
-    if value > max as f64 {
-        return Err(ffi_invalid_arg(FfiError::InvalidArgument {
-            field,
-            reason: format!("must be <= {max}"),
-        }));
-    }
-    Ok(value as u64)
-}
-
-fn safe_f64_to_usize(value: f64, field: &'static str, max: usize) -> napi::Result<usize> {
-    if value.is_nan() || value.is_infinite() || value < 0.0 {
-        return Err(ffi_invalid_arg(FfiError::InvalidArgument {
-            field,
-            reason: format!("expected a non-negative finite number, got {value}"),
-        }));
-    }
-    if value.fract() != 0.0 {
-        return Err(ffi_invalid_arg(FfiError::InvalidArgument {
-            field,
-            reason: "must be an integer".to_string(),
-        }));
-    }
-    if value > max as f64 {
-        return Err(ffi_invalid_arg(FfiError::InvalidArgument {
-            field,
-            reason: format!("must be <= {max}"),
-        }));
-    }
-    Ok(value as usize)
-}
-
 /// Extract a `u64` handle from a [`BigInt`].
 ///
 /// Returns `InvalidArg` when the BigInt value was out of `u64` range (i.e.
@@ -353,6 +307,15 @@ pub async fn create_endpoint(options: Option<JsNodeOptions>) -> napi::Result<JsE
     install_panic_hook();
     let opts = options
         .map(|o| -> napi::Result<NodeOptions> {
+            let endpoint = coerce_endpoint_options(RawEndpointOptions {
+                idle_timeout_ms: o.idle_timeout,
+                pool_idle_timeout_ms: o.pool_idle_timeout_ms,
+                handle_ttl_ms: o.handle_ttl,
+                sweep_interval_ms: o.sweep_interval,
+                max_header_bytes: o.max_header_bytes,
+                compression_level: o.compression_level,
+            })
+            .map_err(ffi_adapter_invalid_arg)?;
             Ok(NodeOptions {
                 key: match o.key {
                     Some(k) => {
@@ -371,10 +334,7 @@ pub async fn create_endpoint(options: Option<JsNodeOptions>) -> napi::Result<JsE
                     relay_mode: o.relay_mode,
                     relays: o.relays.unwrap_or_default(),
                     bind_addrs: o.bind_addrs.unwrap_or_default(),
-                    idle_timeout_ms: o
-                        .idle_timeout
-                        .map(|t| safe_f64_to_u64(t, "idleTimeout", MAX_TIMEOUT_MS))
-                        .transpose()?,
+                    idle_timeout_ms: endpoint.idle_timeout_ms,
                     proxy_url: o.proxy_url,
                     proxy_from_env: o.proxy_from_env.unwrap_or(false),
                     disabled: o.disable_networking.unwrap_or(false),
@@ -385,47 +345,29 @@ pub async fn create_endpoint(options: Option<JsNodeOptions>) -> napi::Result<JsE
                 },
                 pool: PoolOptions {
                     max_connections: o.max_pooled_connections.map(|v| v as usize),
-                    idle_timeout_ms: o
-                        .pool_idle_timeout_ms
-                        .map(|v| safe_f64_to_u64(v, "poolIdleTimeoutMs", MAX_TIMEOUT_MS))
-                        .transpose()?,
+                    idle_timeout_ms: endpoint.pool_idle_timeout_ms,
                 },
                 streaming: StreamingOptions {
                     channel_capacity: o.channel_capacity.map(|v| v as usize),
                     max_chunk_size_bytes: o.max_chunk_size_bytes.map(|v| v as usize),
                     drain_timeout_ms: None,
-                    handle_ttl_ms: o
-                        .handle_ttl
-                        .map(|v| safe_f64_to_u64(v, "handleTtl", MAX_TIMEOUT_MS))
-                        .transpose()?,
-                    sweep_interval_ms: o
-                        .sweep_interval
-                        .map(|v| safe_f64_to_u64(v, "sweepInterval", MAX_TIMEOUT_MS))
-                        .transpose()?,
+                    handle_ttl_ms: endpoint.handle_ttl_ms,
+                    sweep_interval_ms: endpoint.sweep_interval_ms,
                 },
                 capabilities: Vec::new(),
                 keylog: o.keylog.unwrap_or(false),
-                max_header_size: o
-                    .max_header_bytes
-                    .map(|v| safe_f64_to_usize(v, "maxHeaderBytes", MAX_HEADER_BYTES))
-                    .transpose()?,
+                max_header_size: endpoint.max_header_bytes,
                 max_response_body_bytes: None,
                 // NODE-003: enable compression when level or minBodyBytes is provided.
                 compression: if o.compression_min_body_bytes.is_some()
                     || o.compression_level.is_some()
                 {
-                    // ISS-020: validate compression level range before cast.
-                    let level = o
-                        .compression_level
-                        .map(iroh_http_adapter::validate_compression_level)
-                        .transpose()
-                        .map_err(ffi_adapter_invalid_arg)?;
                     Some(iroh_http_core::CompressionOptions {
                         min_body_bytes: o
                             .compression_min_body_bytes
                             .map(|v| v as usize)
                             .unwrap_or(iroh_http_core::CompressionOptions::DEFAULT_MIN_BODY_BYTES),
-                        level,
+                        level: endpoint.compression_level,
                     })
                 } else {
                     None
@@ -1005,35 +947,32 @@ pub async fn raw_fetch(
     max_response_body_bytes: Option<f64>,
 ) -> napi::Result<JsFfiResponse> {
     let ep = get_endpoint(endpoint_handle)?;
-    validate_node_id(&node_id).map_err(ffi_adapter_invalid_arg)?;
-    validate_url(&url).map_err(ffi_adapter_invalid_arg)?;
-    validate_method(&method).map_err(ffi_adapter_invalid_arg)?;
-    validate_direct_addrs(&direct_addrs).map_err(ffi_adapter_invalid_arg)?;
-
-    let pairs = validate_header_rows(headers).map_err(ffi_adapter_invalid_arg)?;
+    let opts = coerce_fetch_options(RawFetchOptions {
+        node_id,
+        url,
+        method,
+        direct_addrs,
+        headers,
+        timeout_ms,
+        max_response_body_bytes,
+    })
+    .map_err(ffi_adapter_invalid_arg)?;
 
     let req_body_reader = req_body_handle
         .map(get_handle)
         .transpose()?
         .and_then(|h| ep.handles().claim_pending_reader(h));
 
-    let addrs =
-        parse_direct_addrs(&direct_addrs).map_err(|e| napi::Error::new(Status::InvalidArg, e))?;
-    let timeout = timeout_ms
-        .map(|ms| adapter_safe_f64_to_u64(ms, "timeoutMs", MAX_TIMEOUT_MS))
-        .transpose()
-        .map_err(ffi_adapter_invalid_arg)?
-        .map(std::time::Duration::from_millis);
-    let max_resp = max_response_body_bytes
-        .map(|b| adapter_safe_f64_to_usize(b, "maxResponseBodyBytes", MAX_BODY_BYTES))
-        .transpose()
-        .map_err(ffi_adapter_invalid_arg)?;
+    let addrs = parse_direct_addrs(&opts.direct_addrs)
+        .map_err(|e| napi::Error::new(Status::InvalidArg, e))?;
+    let timeout = opts.timeout_ms.map(std::time::Duration::from_millis);
+    let max_resp = opts.max_response_body_bytes;
     let res = iroh_http_core::fetch(
         &ep,
-        &node_id,
-        &url,
-        &method,
-        &pairs,
+        &opts.node_id,
+        &opts.url,
+        &opts.method,
+        &opts.headers,
         req_body_reader,
         Some(get_handle(fetch_token)?),
         addrs.as_deref(),
@@ -1132,29 +1071,22 @@ pub async fn raw_serve(
             load_shed: None,
             decompress: None,
         });
+        let serve = coerce_serve_options(RawServeOptions {
+            request_timeout_ms: o.request_timeout,
+            max_request_body_wire_bytes: o.max_request_body_wire_bytes,
+            max_request_body_decoded_bytes: o.max_request_body_decoded_bytes,
+            max_total_connections: o.max_total_connections,
+            drain_timeout_ms: o.drain_timeout,
+        })
+        .map_err(ffi_adapter_invalid_arg)?;
         iroh_http_core::ServeOptions {
             max_concurrency: o.max_concurrency.map(|v| v as usize),
             max_connections_per_peer: o.max_connections_per_peer.map(|v| v as usize),
-            request_timeout_ms: o
-                .request_timeout
-                .map(|v| safe_f64_to_u64(v, "requestTimeout", MAX_TIMEOUT_MS))
-                .transpose()?,
-            max_request_body_wire_bytes: o
-                .max_request_body_wire_bytes
-                .map(|v| safe_f64_to_usize(v, "maxRequestBodyWireBytes", MAX_BODY_BYTES))
-                .transpose()?,
-            max_request_body_decoded_bytes: o
-                .max_request_body_decoded_bytes
-                .map(|v| safe_f64_to_usize(v, "maxRequestBodyDecodedBytes", MAX_BODY_BYTES))
-                .transpose()?,
-            max_total_connections: o
-                .max_total_connections
-                .map(|v| safe_f64_to_usize(v, "maxTotalConnections", MAX_TOTAL_CONNECTIONS))
-                .transpose()?,
-            drain_timeout_ms: o
-                .drain_timeout
-                .map(|v| safe_f64_to_u64(v, "drainTimeout", MAX_TIMEOUT_MS))
-                .transpose()?,
+            request_timeout_ms: serve.request_timeout_ms,
+            max_request_body_wire_bytes: serve.max_request_body_wire_bytes,
+            max_request_body_decoded_bytes: serve.max_request_body_decoded_bytes,
+            max_total_connections: serve.max_total_connections,
+            drain_timeout_ms: serve.drain_timeout_ms,
             load_shed: o.load_shed,
             decompression: o.decompress,
         }
@@ -1554,33 +1486,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_url_rejects_null_byte() {
-        let result = validate_url("httpi://peer/\x00x");
-        assert!(matches!(
-            result,
-            Err(AdapterInputError::InvalidEncoding { field: "url" })
-        ));
-    }
-
-    #[test]
     fn validate_headers_rejects_malformed_pair() {
         let result = validate_header_rows(vec![vec!["x".to_string()]]);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn timeout_conversion_rejects_too_large() {
-        let too_large = safe_f64_to_u64(
-            (MAX_TIMEOUT_MS + 1) as f64,
-            "requestTimeout",
-            MAX_TIMEOUT_MS,
-        );
-        assert!(too_large.is_err());
-    }
-
-    #[test]
-    fn timeout_conversion_rejects_fractional() {
-        let fractional = safe_f64_to_u64(1.5, "requestTimeout", MAX_TIMEOUT_MS);
-        assert!(fractional.is_err());
     }
 }

--- a/packages/iroh-http-tauri/src/commands.rs
+++ b/packages/iroh-http-tauri/src/commands.rs
@@ -14,10 +14,9 @@ use tauri::Manager;
 use crate::state;
 
 use iroh_http_adapter::{
-    core_error_to_json, format_error_json, safe_f64_to_u64, safe_f64_to_usize,
-    send_undeliverable_rejection, validate_compression_level, validate_direct_addrs,
-    validate_header_rows, validate_method, validate_node_id, validate_url, MAX_BODY_BYTES,
-    MAX_HEADER_BYTES, MAX_TIMEOUT_MS, MAX_TOTAL_CONNECTIONS,
+    coerce_endpoint_options, coerce_fetch_options, coerce_serve_options, core_error_to_json,
+    format_error_json, send_undeliverable_rejection, validate_header_rows, RawEndpointOptions,
+    RawFetchOptions, RawServeOptions,
 };
 
 // ── Endpoint ──────────────────────────────────────────────────────────────────
@@ -67,6 +66,15 @@ pub async fn create_endpoint<R: tauri::Runtime>(
 ) -> Result<EndpointInfoPayload, String> {
     let opts = args
         .map(|a| -> Result<NodeOptions, String> {
+            let endpoint = coerce_endpoint_options(RawEndpointOptions {
+                idle_timeout_ms: a.idle_timeout,
+                pool_idle_timeout_ms: a.pool_idle_timeout_ms,
+                handle_ttl_ms: a.handle_ttl,
+                sweep_interval_ms: a.sweep_interval,
+                max_header_bytes: a.max_header_bytes,
+                compression_level: a.compression_level,
+            })
+            .map_err(|e| e.to_json())?;
             Ok(NodeOptions {
                 key: match a.key {
                     Some(k) => {
@@ -84,11 +92,7 @@ pub async fn create_endpoint<R: tauri::Runtime>(
                     relay_mode: a.relay_mode,
                     relays: a.relays.unwrap_or_default(),
                     bind_addrs: a.bind_addrs.unwrap_or_default(),
-                    idle_timeout_ms: a
-                        .idle_timeout
-                        .map(|v| safe_f64_to_u64(v, "idleTimeout", MAX_TIMEOUT_MS))
-                        .transpose()
-                        .map_err(|e| e.to_json())?,
+                    idle_timeout_ms: endpoint.idle_timeout_ms,
                     proxy_url: a.proxy_url,
                     proxy_from_env: a.proxy_from_env.unwrap_or(false),
                     disabled: a.disable_networking.unwrap_or(false),
@@ -99,49 +103,27 @@ pub async fn create_endpoint<R: tauri::Runtime>(
                 },
                 pool: PoolOptions {
                     max_connections: a.max_pooled_connections,
-                    idle_timeout_ms: a
-                        .pool_idle_timeout_ms
-                        .map(|v| safe_f64_to_u64(v, "poolIdleTimeoutMs", MAX_TIMEOUT_MS))
-                        .transpose()
-                        .map_err(|e| e.to_json())?,
+                    idle_timeout_ms: endpoint.pool_idle_timeout_ms,
                 },
                 streaming: StreamingOptions {
                     channel_capacity: a.channel_capacity,
                     max_chunk_size_bytes: a.max_chunk_size_bytes,
                     drain_timeout_ms: None,
-                    handle_ttl_ms: a
-                        .handle_ttl
-                        .map(|v| safe_f64_to_u64(v, "handleTtl", MAX_TIMEOUT_MS))
-                        .transpose()
-                        .map_err(|e| e.to_json())?,
-                    sweep_interval_ms: a
-                        .sweep_interval
-                        .map(|v| safe_f64_to_u64(v, "sweepInterval", MAX_TIMEOUT_MS))
-                        .transpose()
-                        .map_err(|e| e.to_json())?,
+                    handle_ttl_ms: endpoint.handle_ttl_ms,
+                    sweep_interval_ms: endpoint.sweep_interval_ms,
                 },
                 capabilities: Vec::new(),
                 keylog: a.keylog.unwrap_or(false),
-                max_header_size: a
-                    .max_header_bytes
-                    .map(|v| safe_f64_to_usize(v, "maxHeaderBytes", MAX_HEADER_BYTES))
-                    .transpose()
-                    .map_err(|e| e.to_json())?,
+                max_header_size: endpoint.max_header_bytes,
                 max_response_body_bytes: None,
                 compression: if a.compression_min_body_bytes.is_some()
                     || a.compression_level.is_some()
                 {
-                    // ISS-020: validate compression level range before cast.
-                    let level = a
-                        .compression_level
-                        .map(validate_compression_level)
-                        .transpose()
-                        .map_err(|e| e.to_json())?;
                     Some(iroh_http_core::CompressionOptions {
                         min_body_bytes: a
                             .compression_min_body_bytes
                             .unwrap_or(iroh_http_core::CompressionOptions::DEFAULT_MIN_BODY_BYTES),
-                        level,
+                        level: endpoint.compression_level,
                     })
                 } else {
                     None
@@ -524,34 +506,30 @@ pub async fn fetch(args: RawFetchArgs) -> Result<FfiResponsePayload, String> {
         )
     })?;
 
-    let pairs = validate_header_rows(args.headers).map_err(|e| e.to_json())?;
-    validate_node_id(&args.node_id).map_err(|e| e.to_json())?;
-    validate_url(&args.url).map_err(|e| e.to_json())?;
-    validate_method(&args.method).map_err(|e| e.to_json())?;
-    validate_direct_addrs(&args.direct_addrs).map_err(|e| e.to_json())?;
+    let opts = coerce_fetch_options(RawFetchOptions {
+        node_id: args.node_id,
+        url: args.url,
+        method: args.method,
+        direct_addrs: args.direct_addrs,
+        headers: args.headers,
+        timeout_ms: args.timeout_ms,
+        max_response_body_bytes: args.max_response_body_bytes,
+    })
+    .map_err(|e| e.to_json())?;
 
     let req_body_reader = args
         .req_body_handle
         .and_then(|h| ep.handles().claim_pending_reader(h));
 
-    let addrs = parse_direct_addrs(&args.direct_addrs)?;
-    let timeout = args
-        .timeout_ms
-        .map(|ms| safe_f64_to_u64(ms, "timeoutMs", MAX_TIMEOUT_MS))
-        .transpose()
-        .map_err(|e| e.to_json())?
-        .map(std::time::Duration::from_millis);
-    let max_response_body_bytes = args
-        .max_response_body_bytes
-        .map(|b| safe_f64_to_usize(b, "maxResponseBodyBytes", MAX_BODY_BYTES))
-        .transpose()
-        .map_err(|e| e.to_json())?;
+    let addrs = parse_direct_addrs(&opts.direct_addrs)?;
+    let timeout = opts.timeout_ms.map(std::time::Duration::from_millis);
+    let max_response_body_bytes = opts.max_response_body_bytes;
     let res = iroh_http_core::fetch(
         &ep,
-        &args.node_id,
-        &args.url,
-        &args.method,
-        &pairs,
+        &opts.node_id,
+        &opts.url,
+        &opts.method,
+        &opts.headers,
         req_body_reader,
         args.fetch_token,
         addrs.as_deref(),
@@ -618,34 +596,22 @@ pub async fn serve(
         )
     })?;
 
+    let serve = coerce_serve_options(RawServeOptions {
+        request_timeout_ms: args.request_timeout,
+        max_request_body_wire_bytes: args.max_request_body_wire_bytes,
+        max_request_body_decoded_bytes: args.max_request_body_decoded_bytes,
+        max_total_connections: args.max_total_connections,
+        drain_timeout_ms: args.drain_timeout,
+    })
+    .map_err(|e| e.to_json())?;
     let serve_opts = iroh_http_core::ServeOptions {
         max_concurrency: args.max_concurrency,
         max_connections_per_peer: args.max_connections_per_peer,
-        request_timeout_ms: args
-            .request_timeout
-            .map(|v| safe_f64_to_u64(v, "requestTimeout", MAX_TIMEOUT_MS))
-            .transpose()
-            .map_err(|e| e.to_json())?,
-        max_request_body_wire_bytes: args
-            .max_request_body_wire_bytes
-            .map(|v| safe_f64_to_usize(v, "maxRequestBodyWireBytes", MAX_BODY_BYTES))
-            .transpose()
-            .map_err(|e| e.to_json())?,
-        max_request_body_decoded_bytes: args
-            .max_request_body_decoded_bytes
-            .map(|v| safe_f64_to_usize(v, "maxRequestBodyDecodedBytes", MAX_BODY_BYTES))
-            .transpose()
-            .map_err(|e| e.to_json())?,
-        max_total_connections: args
-            .max_total_connections
-            .map(|v| safe_f64_to_usize(v, "maxTotalConnections", MAX_TOTAL_CONNECTIONS))
-            .transpose()
-            .map_err(|e| e.to_json())?,
-        drain_timeout_ms: args
-            .drain_timeout
-            .map(|v| safe_f64_to_u64(v, "drainTimeout", MAX_TIMEOUT_MS))
-            .transpose()
-            .map_err(|e| e.to_json())?,
+        request_timeout_ms: serve.request_timeout_ms,
+        max_request_body_wire_bytes: serve.max_request_body_wire_bytes,
+        max_request_body_decoded_bytes: serve.max_request_body_decoded_bytes,
+        max_total_connections: serve.max_total_connections,
+        drain_timeout_ms: serve.drain_timeout_ms,
         load_shed: args.load_shed,
         decompression: args.decompress,
     };


### PR DESCRIPTION
## Slice D — `coerce_*` seam consolidation (completes epic #289)

Pure refactor, no behavior change. Consolidates the per-adapter fetch/serve/endpoint validation+coercion into a single seam in `iroh-http-adapter`, so each Rust adapter decode site becomes: **deserialize platform shape → one `coerce_*` call → map the checked result into core types.**

### Adapter (`crates/iroh-http-adapter/src/lib.rs`)
Adds three seam functions + their raw-input / checked-output structs:
- `coerce_fetch_options(RawFetchOptions) -> FetchOptions`
- `coerce_endpoint_options(RawEndpointOptions) -> EndpointOptions`
- `coerce_serve_options(RawServeOptions) -> ServeOptions`

Each **composes the existing** `validate_*`/`safe_f64_*`/`validate_header_rows`/`validate_compression_level` helpers — no validation logic is reimplemented. (Three functions rather than two because `createEndpoint`/bind and `serve` are distinct FFI calls with disjoint numeric knobs; `compressionLevel` is an endpoint knob.)

### Wiring (all three adapters, same slice)
- **Node** `raw_fetch` + `create_endpoint` + `raw_serve`
- **Deno** `raw_fetch_impl` + `create_endpoint` + `serve_start`
- **Tauri** `fetch` + `create_endpoint` + `serve`

Platform glue (body-handle claim, `parse_direct_addrs`, nested core struct assembly) stays at each call site. Removes now-dead local helpers (Node `safe_f64_to_u64/usize` wrappers, Deno `coerce_opt_u64/usize`) and unused per-adapter validator imports. Fetch validation now runs in one canonical order (node id → url → method → direct addrs → headers → numeric knobs) across all runtimes.

### Behavior parity
Byte-identical to the A+B+C implementation: same reject codes, messages, and defaults. The `tests/suites/adapter-validation.mjs` cross-runtime conformance suite passes **unchanged** (8/8 on Node and Deno). Adds adapter-crate unit tests for the three `coerce_*` functions.

### Verification
- `cargo test -p iroh-http-adapter` → 21 passed
- `cargo clippy --workspace -- -D warnings` + Tauri manifest clippy → clean
- Conformance: Node 8/8, Deno 8/8 (unchanged)
- Full `npm run ci` → all checks passed
- Build churn reverted (`index.js`, `deno.lock`); no `index.d.ts` change; no version bumps

Closes #289