### PR TITLE
refactor(js): unify option normalisers (#312) and consolidate deno readChunk (#313)

### DIFF
--- a/packages/iroh-http-deno/src/adapter.ts
+++ b/packages/iroh-http-deno/src/adapter.ts
@@ -29,11 +29,14 @@ import type {
   TransportEventPayload,
 } from "@momics/iroh-http-shared/adapter";
 import {
+  bigintToSafeNumber,
   classifyBindError,
   classifyError,
   decodeBase64,
   encodeBase64,
   isEndpointGoneError,
+  normaliseCompression,
+  normaliseDiscovery,
   normaliseRelayMode,
 } from "@momics/iroh-http-shared";
 import { download } from "@denosaurs/plug";
@@ -365,18 +368,11 @@ const METHOD_BUFS: Record<string, Uint8Array> = Object.fromEntries(
 );
 
 // ISS-032 / #252: bigint handles are slotmap u64 keys (32-bit slot + 32-bit
-// version); practical values are well within Number.MAX_SAFE_INTEGER. Convert
-// to a JS number only after asserting the safe range, throwing early rather
-// than silently corrupting resource identity. Shared by the generic `call()`
-// path and the `rawFetch` fast-path so both fail loudly and identically.
-export function bigintToSafeNumber(value: bigint, field = "handle"): number {
-  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new RangeError(
-      `[iroh-http] ${field} value ${value} exceeds safe integer range and cannot be safely serialised`,
-    );
-  }
-  return Number(value);
-}
+// version); practical values are well within Number.MAX_SAFE_INTEGER. The
+// safe-range guard now lives in `@momics/iroh-http-shared`; it is re-exported
+// here under its original name so the generic `call()` path, the `rawFetch`
+// fast-path, and the #252 regression test keep importing it from this module.
+export { bigintToSafeNumber };
 
 /** Reusable buffer hint for estimating output size of `call()` responses. */ async function call<
   T,
@@ -930,21 +926,6 @@ export function _closeAllForTesting(): void {
   _closeAllSync();
 }
 
-/** Normalise the `discovery` option into flat fields for the Rust adapter. */
-function normaliseDiscovery(
-  disc?: import("@momics/iroh-http-shared").NodeOptions["discovery"],
-): {
-  dnsEnabled: boolean;
-  dnsServerUrl?: string;
-} {
-  if (!disc) return { dnsEnabled: true };
-  if (disc.dns === false) return { dnsEnabled: false };
-  if (typeof disc.dns === "object" && disc.dns !== null) {
-    return { dnsEnabled: true, dnsServerUrl: disc.dns.serverUrl };
-  }
-  return { dnsEnabled: true };
-}
-
 export async function createEndpointInfo(
   options?: NodeOptions,
 ): Promise<EndpointInfo> {
@@ -958,6 +939,7 @@ export async function createEndpointInfo(
     options?.relay,
   );
   const discovery = normaliseDiscovery(options?.discovery);
+  const compression = normaliseCompression(options?.compression);
   const bindAddrs = options?.bindAddr
     ? Array.isArray(options.bindAddr) ? options.bindAddr : [options.bindAddr]
     : null;
@@ -982,14 +964,8 @@ export async function createEndpointInfo(
     proxyUrl: options?.proxy?.url ?? null,
     proxyFromEnv: options?.proxy?.fromEnv ?? null,
     keylog: options?.debug?.keylog ?? null,
-    compressionLevel: typeof options?.compression === "object"
-      ? (options.compression.level ?? null)
-      : options?.compression
-      ? 3
-      : null,
-    compressionMinBodyBytes: typeof options?.compression === "object"
-      ? (options.compression.minBodyBytes ?? null)
-      : null,
+    compressionLevel: compression.level ?? null,
+    compressionMinBodyBytes: compression.minBodyBytes ?? null,
     maxHeaderBytes: options?.limits?.maxHeaderBytes ?? null,
   }).catch((e: unknown) => {
     throw classifyBindError(e);

--- a/packages/iroh-http-deno/src/adapter.ts
+++ b/packages/iroh-http-deno/src/adapter.ts
@@ -467,6 +467,99 @@ function takeLastStreamError(eh: bigint, handle: bigint): string {
   return `nextChunk: stream error on handle ${handle}`;
 }
 
+/**
+ * Read the next body chunk for `handle` on endpoint `eh`, applying the
+ * buffer-grow/retry protocol of `iroh_http_try_next_chunk` /
+ * `iroh_http_next_chunk`.
+ *
+ * Shared by {@link makeBridge}'s bridge object and {@link DenoAdapter} so the
+ * grow/retry semantics live in exactly one place (#313).
+ *
+ * Protocol:
+ * - #126: try the sync non-blocking read first — avoids ~100–200µs of
+ *   spawn_blocking scheduling overhead when data is already buffered.
+ * - `> 0`  → chunk of that many bytes.
+ * - `0`    → clean EOF.
+ * - `< -2` → buffer too small; the magnitude is the required size. Grow and
+ *   retry sync once.
+ * - `-1`   → hard error (endpoint gone, handle invalid, stream reset).
+ * - `-2`   → no data buffered yet; fall back to the async FFI path (which
+ *   applies the same grow-and-retry-once protocol via `iroh_http_next_chunk`).
+ */
+async function readChunk(
+  eh: bigint,
+  handle: bigint,
+): Promise<Uint8Array | null> {
+  // #126: Try sync non-blocking read first — avoids ~100–200µs of
+  // spawn_blocking scheduling overhead when data is already buffered.
+  // DENO-001: allocate a per-call buffer so concurrent reads on different
+  // handles do not share memory and corrupt each other's data.
+  const syncBuf = new Uint8Array(chunkBufHint) as Uint8Array<ArrayBuffer>;
+  const syncN = lib.symbols.iroh_http_try_next_chunk(
+    eh,
+    handle,
+    syncBuf,
+    BigInt(syncBuf.byteLength),
+  ) as number;
+
+  if (syncN > 0) {
+    // Data available — return it without entering the async FFI pool.
+    chunkBufHint = Math.min(Math.max(chunkBufHint, syncN), MAX_CHUNK_BUF);
+    return syncBuf.slice(0, syncN);
+  }
+  if (syncN === 0) return null; // EOF
+  if (syncN < -2) {
+    // Buffer too small — grow and retry sync.
+    const bigBuf = new Uint8Array(-syncN) as Uint8Array<ArrayBuffer>;
+    const retryN = lib.symbols.iroh_http_try_next_chunk(
+      eh,
+      handle,
+      bigBuf,
+      BigInt(bigBuf.byteLength),
+    ) as number;
+    if (retryN > 0) {
+      chunkBufHint = Math.min(Math.max(chunkBufHint, retryN), MAX_CHUNK_BUF);
+      return bigBuf.slice(0, retryN);
+    }
+    if (retryN === 0) return null;
+    // Fall through to async if sync retry also fails.
+  }
+  // syncN === -1 (hard error) or -2 (no data yet) — fall back to async.
+  if (syncN === -1) {
+    throw new Error(takeLastStreamError(eh, handle));
+  }
+
+  // -2: No data available yet — use the async path.
+  let buf = new Uint8Array(chunkBufHint) as Uint8Array<ArrayBuffer>;
+  let n = (await lib.symbols.iroh_http_next_chunk(
+    eh,
+    handle,
+    buf,
+    BigInt(buf.byteLength),
+  )) as number;
+  if (n < -1) {
+    // Return value encodes the required size as a negative number.
+    // Grow the buffer and retry exactly once.
+    buf = new Uint8Array(-n) as Uint8Array<ArrayBuffer>;
+    n = (await lib.symbols.iroh_http_next_chunk(
+      eh,
+      handle,
+      buf,
+      BigInt(buf.byteLength),
+    )) as number;
+  }
+  // n === -1  → hard error (endpoint gone, handle invalid, stream reset).
+  // n === 0   → clean EOF.
+  // n > 0     → chunk of n bytes.
+  if (n === -1) {
+    throw new Error(takeLastStreamError(eh, handle));
+  }
+  if (n === 0) return null;
+  // Update hint so future calls start with a better-sized buffer (capped).
+  chunkBufHint = Math.min(Math.max(chunkBufHint, n), MAX_CHUNK_BUF);
+  return buf.slice(0, n);
+}
+
 // ── Bridge implementation ─────────────────────────────────────────────────────
 
 export function makeBridge(endpointHandle: number) {
@@ -474,78 +567,10 @@ export function makeBridge(endpointHandle: number) {
   // version bits in the upper 32 bits, so we must not truncate to u32).
   const eh = BigInt(endpointHandle);
   return {
-    async nextChunk(handle: bigint): Promise<Uint8Array | null> {
-      // #126: Try sync non-blocking read first — avoids ~100–200µs of
-      // spawn_blocking scheduling overhead when data is already buffered.
-      const syncBuf = new Uint8Array(chunkBufHint) as Uint8Array<ArrayBuffer>;
-      const syncN = lib.symbols.iroh_http_try_next_chunk(
-        eh,
-        handle,
-        syncBuf,
-        BigInt(syncBuf.byteLength),
-      ) as number;
-
-      if (syncN > 0) {
-        // Data available — return it without entering the async FFI pool.
-        chunkBufHint = Math.min(Math.max(chunkBufHint, syncN), MAX_CHUNK_BUF);
-        return syncBuf.slice(0, syncN);
-      }
-      if (syncN === 0) return null; // EOF
-      if (syncN < -2) {
-        // Buffer too small — grow and retry sync.
-        const bigBuf = new Uint8Array(-syncN) as Uint8Array<ArrayBuffer>;
-        const retryN = lib.symbols.iroh_http_try_next_chunk(
-          eh,
-          handle,
-          bigBuf,
-          BigInt(bigBuf.byteLength),
-        ) as number;
-        if (retryN > 0) {
-          chunkBufHint = Math.min(
-            Math.max(chunkBufHint, retryN),
-            MAX_CHUNK_BUF,
-          );
-          return bigBuf.slice(0, retryN);
-        }
-        if (retryN === 0) return null;
-        // Fall through to async if sync retry also fails.
-      }
-      // syncN === -1 (hard error) or -2 (no data yet) — fall back to async.
-      if (syncN === -1) {
-        throw new Error(takeLastStreamError(eh, handle));
-      }
-
-      // -2: No data available yet — use the async path.
-      // DENO-001: allocate a per-call buffer so concurrent reads on different
-      // handles do not share memory and corrupt each other's data.
-      let buf = new Uint8Array(chunkBufHint) as Uint8Array<ArrayBuffer>;
-      let n = (await lib.symbols.iroh_http_next_chunk(
-        eh,
-        handle,
-        buf,
-        BigInt(buf.byteLength),
-      )) as number;
-      if (n < -1) {
-        // Return value encodes the required size as a negative number.
-        // Grow the buffer and retry exactly once.
-        buf = new Uint8Array(-n) as Uint8Array<ArrayBuffer>;
-        n = (await lib.symbols.iroh_http_next_chunk(
-          eh,
-          handle,
-          buf,
-          BigInt(buf.byteLength),
-        )) as number;
-      }
-      // n === -1  → hard error (endpoint gone, handle invalid, stream reset).
-      // n === 0   → clean EOF.
-      // n > 0     → chunk of n bytes.
-      if (n === -1) {
-        throw new Error(takeLastStreamError(eh, handle));
-      }
-      if (n === 0) return null;
-      // Update hint so future calls start with a better-sized buffer (capped).
-      chunkBufHint = Math.min(Math.max(chunkBufHint, n), MAX_CHUNK_BUF);
-      return buf.slice(0, n);
+    nextChunk(handle: bigint): Promise<Uint8Array | null> {
+      // #126: try sync non-blocking read first, then fall back to async —
+      // see the shared readChunk helper for the full grow/retry protocol.
+      return readChunk(eh, handle);
     },
     async sendChunk(handle: bigint, chunk: Uint8Array): Promise<void> {
       // Async FFI — same deadlock concern as the class method.
@@ -1241,65 +1266,10 @@ export class DenoAdapter extends IrohAdapter {
 
   // ── Body streaming ──────────────────────────────────────────────────────────
 
-  async nextChunk(handle: bigint): Promise<Uint8Array | null> {
-    const eh = BigInt(this.#eh);
-    // #126: Try sync non-blocking read first — avoids ~100–200µs of
-    // spawn_blocking scheduling overhead when data is already buffered.
-    const syncBuf = new Uint8Array(chunkBufHint) as Uint8Array<ArrayBuffer>;
-    const syncN = lib.symbols.iroh_http_try_next_chunk(
-      eh,
-      handle,
-      syncBuf,
-      BigInt(syncBuf.byteLength),
-    ) as number;
-
-    if (syncN > 0) {
-      chunkBufHint = Math.min(Math.max(chunkBufHint, syncN), MAX_CHUNK_BUF);
-      return syncBuf.slice(0, syncN);
-    }
-    if (syncN === 0) return null; // EOF
-    if (syncN < -2) {
-      // Buffer too small — grow and retry sync.
-      const bigBuf = new Uint8Array(-syncN) as Uint8Array<ArrayBuffer>;
-      const retryN = lib.symbols.iroh_http_try_next_chunk(
-        eh,
-        handle,
-        bigBuf,
-        BigInt(bigBuf.byteLength),
-      ) as number;
-      if (retryN > 0) {
-        chunkBufHint = Math.min(Math.max(chunkBufHint, retryN), MAX_CHUNK_BUF);
-        return bigBuf.slice(0, retryN);
-      }
-      if (retryN === 0) return null;
-    }
-    if (syncN === -1) {
-      throw new Error(takeLastStreamError(eh, handle));
-    }
-
-    // -2: No data yet — fall back to async path.
-    let buf = new Uint8Array(chunkBufHint) as Uint8Array<ArrayBuffer>;
-    let n = (await lib.symbols.iroh_http_next_chunk(
-      eh,
-      handle,
-      buf,
-      BigInt(buf.byteLength),
-    )) as number;
-    if (n < -1) {
-      buf = new Uint8Array(-n) as Uint8Array<ArrayBuffer>;
-      n = (await lib.symbols.iroh_http_next_chunk(
-        eh,
-        handle,
-        buf,
-        BigInt(buf.byteLength),
-      )) as number;
-    }
-    if (n === -1) {
-      throw new Error(takeLastStreamError(eh, handle));
-    }
-    if (n === 0) return null;
-    chunkBufHint = Math.min(Math.max(chunkBufHint, n), MAX_CHUNK_BUF);
-    return buf.slice(0, n);
+  nextChunk(handle: bigint): Promise<Uint8Array | null> {
+    // #126: try sync non-blocking read first, then fall back to async —
+    // see the shared readChunk helper for the full grow/retry protocol.
+    return readChunk(BigInt(this.#eh), handle);
   }
 
   async sendChunk(handle: bigint, chunk: Uint8Array): Promise<void> {

--- a/packages/iroh-http-node/lib.ts
+++ b/packages/iroh-http-node/lib.ts
@@ -52,6 +52,8 @@ import {
   type IrohNodeWithSecret,
   type NodeAddrInfo,
   type NodeOptions,
+  normaliseCompression,
+  normaliseDiscovery,
   normaliseRelayMode,
   type SecretKey,
 } from "@momics/iroh-http-shared";
@@ -419,18 +421,6 @@ class NodeAdapter extends IrohAdapter {
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-function normaliseDiscovery(disc?: NodeOptions["discovery"]): {
-  dnsEnabled: boolean;
-  dnsServerUrl?: string;
-} {
-  if (!disc) return { dnsEnabled: true };
-  if (disc.dns === false) return { dnsEnabled: false };
-  if (typeof disc.dns === "object" && disc.dns !== null) {
-    return { dnsEnabled: true, dnsServerUrl: disc.dns.serverUrl };
-  }
-  return { dnsEnabled: true };
-}
-
 export { PublicKey, SecretKey } from "@momics/iroh-http-shared";
 export type { IrohNode, IrohNodeWithSecret, NodeOptions };
 
@@ -478,6 +468,7 @@ export async function createNode(
     options?.relay,
   );
   const discovery = normaliseDiscovery(options?.discovery);
+  const compression = normaliseCompression(options?.compression);
   const disableNetworkingFinal = disableNetworking ||
     (options?.disableNetworking ?? false);
   const bindAddrs = options?.bindAddr
@@ -503,14 +494,8 @@ export async function createNode(
         proxyUrl: options.proxy?.url,
         proxyFromEnv: options.proxy?.fromEnv,
         keylog: options.debug?.keylog,
-        compressionLevel: typeof options.compression === "object"
-          ? options.compression.level
-          : options.compression
-          ? 3
-          : undefined,
-        compressionMinBodyBytes: typeof options.compression === "object"
-          ? options.compression.minBodyBytes
-          : undefined,
+        compressionLevel: compression.level,
+        compressionMinBodyBytes: compression.minBodyBytes,
         maxHeaderBytes: options.limits?.maxHeaderBytes,
       }
       : undefined,

--- a/packages/iroh-http-shared/src/index.ts
+++ b/packages/iroh-http-shared/src/index.ts
@@ -60,8 +60,19 @@ export {
   IrohStreamError,
   isEndpointGoneError,
 } from "./errors.js";
-export { decodeBase64, encodeBase64, normaliseRelayMode } from "./utils.js";
-export type { NormalisedRelay } from "./utils.js";
+export {
+  bigintToSafeNumber,
+  decodeBase64,
+  encodeBase64,
+  normaliseCompression,
+  normaliseDiscovery,
+  normaliseRelayMode,
+} from "./utils.js";
+export type {
+  NormalisedCompression,
+  NormalisedDiscovery,
+  NormalisedRelay,
+} from "./utils.js";
 
 export function ticketNodeId(ticket: string): string {
   try {

--- a/packages/iroh-http-shared/src/utils.ts
+++ b/packages/iroh-http-shared/src/utils.ts
@@ -5,7 +5,7 @@
  * and Tauri adapter code.
  */
 
-import type { RelayMode } from "./options/NodeOptions.js";
+import type { NodeOptions, RelayMode } from "./options/NodeOptions.js";
 
 // ── Relay mode normalisation ──────────────────────────────────────────────────
 
@@ -37,6 +37,78 @@ export function normaliseRelayMode(
   }
   // "default" or undefined: use Iroh's public relay servers
   return { relayMode: undefined, relays: null, disableNetworking: false };
+}
+
+// ── Discovery normalisation ───────────────────────────────────────────────────
+
+export interface NormalisedDiscovery {
+  dnsEnabled: boolean;
+  dnsServerUrl?: string;
+}
+
+/**
+ * Normalise the `discovery` option into the flat DNS fields the Rust adapter
+ * expects. DNS-SD is on by default; `dns: false` disables it, and an object
+ * form supplies a custom resolver URL.
+ */
+export function normaliseDiscovery(
+  disc?: NodeOptions["discovery"],
+): NormalisedDiscovery {
+  if (!disc) return { dnsEnabled: true };
+  if (disc.dns === false) return { dnsEnabled: false };
+  if (typeof disc.dns === "object" && disc.dns !== null) {
+    return { dnsEnabled: true, dnsServerUrl: disc.dns.serverUrl };
+  }
+  return { dnsEnabled: true };
+}
+
+// ── Compression normalisation ─────────────────────────────────────────────────
+
+export interface NormalisedCompression {
+  level: number | undefined;
+  minBodyBytes: number | undefined;
+}
+
+/**
+ * Normalise the `compression` option into flat `level`/`minBodyBytes` fields.
+ * `true` selects the default zstd level (3); an object passes its tuning
+ * through untouched; a falsy value leaves both fields unset (`undefined`).
+ *
+ * Callers that serialise to JSON (Deno FFI, Tauri IPC) map the `undefined`
+ * results to `null`; the Node napi bridge treats `undefined` as absent.
+ */
+export function normaliseCompression(
+  compression?: NodeOptions["compression"],
+): NormalisedCompression {
+  if (typeof compression === "object" && compression !== null) {
+    return {
+      level: compression.level,
+      minBodyBytes: compression.minBodyBytes,
+    };
+  }
+  return {
+    level: compression ? 3 : undefined,
+    minBodyBytes: undefined,
+  };
+}
+
+// ── u64 handle guard ──────────────────────────────────────────────────────────
+
+/**
+ * Convert an opaque u64 resource handle (slotmap key: 32-bit slot + 32-bit
+ * generation) to a JS number, rejecting values outside the safe integer range
+ * rather than silently rounding and addressing the wrong resource.
+ *
+ * Shared by the Deno FFI adapter (imported as `bigintToSafeNumber`) and the
+ * Tauri IPC bridge. Regression coverage: #252.
+ */
+export function bigintToSafeNumber(value: bigint, field = "handle"): number {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new RangeError(
+      `[iroh-http] ${field} value ${value} exceeds safe integer range and cannot be safely serialised`,
+    );
+  }
+  return Number(value);
 }
 
 // ── Base64 encoding ───────────────────────────────────────────────────────────

--- a/packages/iroh-http-tauri/guest-js/index.ts
+++ b/packages/iroh-http-tauri/guest-js/index.ts
@@ -4,11 +4,14 @@
 
 import { Channel, invoke } from "@tauri-apps/api/core";
 import {
+  bigintToSafeNumber,
   classifyBindError,
   encodeBase64,
   IrohNode,
   type IrohNodeWithSecret,
   type NodeOptions,
+  normaliseCompression,
+  normaliseDiscovery,
   normaliseRelayMode,
   type SecretKey,
 } from "@momics/iroh-http-shared";
@@ -42,21 +45,6 @@ interface TauriRequestPayload {
   remoteNodeId: string;
 }
 
-/**
- * Convert an opaque u64 resource handle (slotmap key: 32-bit slot + 32-bit
- * generation) to a JS number for IPC, rejecting values outside the safe
- * integer range rather than silently rounding and addressing the wrong
- * resource. Mirrors the Deno adapter's `bigintToSafeNumber` guard (#252).
- */
-function u64Handle(value: bigint, field = "handle"): number {
-  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new RangeError(
-      `[iroh-http-tauri] ${field} value ${value} exceeds safe integer range and cannot be safely serialised`,
-    );
-  }
-  return Number(value);
-}
-
 // ── TauriAdapter ──────────────────────────────────────────────────────────────
 
 class TauriAdapter extends IrohAdapter {
@@ -72,7 +60,7 @@ class TauriAdapter extends IrohAdapter {
   nextChunk(handle: bigint): Promise<Uint8Array | null> {
     // Sync fast path: if data is already buffered, skip async IPC overhead.
     // Protocol: first byte is 0x01 (data follows) or 0x00 (EOF).
-    const safeHandle = u64Handle(handle);
+    const safeHandle = bigintToSafeNumber(handle);
     return invoke<ArrayBuffer>(`${PLUGIN}|try_next_chunk`, {
       endpointHandle: this.#epHandle,
       handle: safeHandle,
@@ -97,7 +85,7 @@ class TauriAdapter extends IrohAdapter {
     return invoke(`${PLUGIN}|send_chunk`, chunk, {
       headers: {
         "iroh-ep": String(this.#epHandle),
-        "iroh-handle": String(u64Handle(handle)),
+        "iroh-handle": String(bigintToSafeNumber(handle)),
       },
     });
   }
@@ -105,14 +93,14 @@ class TauriAdapter extends IrohAdapter {
   finishBody(handle: bigint): Promise<void> {
     return invoke(`${PLUGIN}|finish_body`, {
       endpointHandle: this.#epHandle,
-      handle: u64Handle(handle),
+      handle: bigintToSafeNumber(handle),
     });
   }
 
   cancelRequest(handle: bigint): Promise<void> {
     return invoke(`${PLUGIN}|cancel_request`, {
       endpointHandle: this.#epHandle,
-      handle: u64Handle(handle),
+      handle: bigintToSafeNumber(handle),
     });
   }
 
@@ -124,7 +112,7 @@ class TauriAdapter extends IrohAdapter {
   cancelFetch(token: bigint): void {
     void invoke(`${PLUGIN}|cancel_in_flight`, {
       endpointHandle: this.#epHandle,
-      token: u64Handle(token, "token"),
+      token: bigintToSafeNumber(token, "token"),
     });
   }
 
@@ -158,10 +146,10 @@ class TauriAdapter extends IrohAdapter {
         method,
         headers,
         reqBodyHandle: reqBodyHandle != null
-          ? u64Handle(reqBodyHandle, "reqBodyHandle")
+          ? bigintToSafeNumber(reqBodyHandle, "reqBodyHandle")
           : null,
         fetchToken: fetchToken != null
-          ? u64Handle(fetchToken, "fetchToken")
+          ? bigintToSafeNumber(fetchToken, "fetchToken")
           : null,
         directAddrs: directAddrs ?? null,
         timeoutMs: fetchOptions?.timeoutMs ?? null,
@@ -220,7 +208,7 @@ class TauriAdapter extends IrohAdapter {
           await invoke(`${PLUGIN}|respond_to_request`, {
             args: {
               endpointHandle: Number(endpointHandle),
-              reqHandle: u64Handle(payload.reqHandle, "reqHandle"),
+              reqHandle: bigintToSafeNumber(payload.reqHandle, "reqHandle"),
               status: head.status,
               headers: head.headers,
             },
@@ -230,7 +218,7 @@ class TauriAdapter extends IrohAdapter {
           await invoke(`${PLUGIN}|respond_to_request`, {
             args: {
               endpointHandle: Number(endpointHandle),
-              reqHandle: u64Handle(BigInt(raw.reqHandle), "reqHandle"),
+              reqHandle: bigintToSafeNumber(BigInt(raw.reqHandle), "reqHandle"),
               status: 500,
               headers: [],
             },
@@ -525,18 +513,6 @@ function installLifecycleListener(
   return () => document.removeEventListener("visibilitychange", handler);
 }
 
-function normaliseDiscovery(disc?: NodeOptions["discovery"]): {
-  dnsEnabled: boolean;
-  dnsServerUrl?: string;
-} {
-  if (!disc) return { dnsEnabled: true };
-  if (disc.dns === false) return { dnsEnabled: false };
-  if (typeof disc.dns === "object" && disc.dns !== null) {
-    return { dnsEnabled: true, dnsServerUrl: disc.dns.serverUrl };
-  }
-  return { dnsEnabled: true };
-}
-
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -597,6 +573,7 @@ export async function createNode(options?: NodeOptions): Promise<IrohNode> {
     options?.relay,
   );
   const discovery = normaliseDiscovery(options?.discovery);
+  const compression = normaliseCompression(options?.compression);
   const bindAddrs = options?.bindAddr
     ? (Array.isArray(options.bindAddr) ? options.bindAddr : [options.bindAddr])
     : null;
@@ -623,14 +600,8 @@ export async function createNode(options?: NodeOptions): Promise<IrohNode> {
         proxyUrl: options.proxy?.url ?? null,
         proxyFromEnv: options.proxy?.fromEnv ?? null,
         keylog: options.debug?.keylog ?? null,
-        compressionLevel: typeof options.compression === "object"
-          ? options.compression.level ?? null
-          : options.compression
-          ? 3
-          : null,
-        compressionMinBodyBytes: typeof options.compression === "object"
-          ? options.compression.minBodyBytes ?? null
-          : null,
+        compressionLevel: compression.level ?? null,
+        compressionMinBodyBytes: compression.minBodyBytes ?? null,
         maxHeaderBytes: options.limits?.maxHeaderBytes ?? null,
       }
       : null,


### PR DESCRIPTION
Two pure DX refactors with **no behavior change**, one commit each. The cross-runtime conformance suite stays byte-identical green.

## Commit 1 — `refactor(shared): unify JS option normalisers into iroh-http-shared (#312)`

The discovery, compression, and u64 handle-guard normalisers were hand-copied across the Node, Deno, and Tauri adapters. Lifted the shared versions into `packages/iroh-http-shared/src/utils.ts` (alongside `normaliseRelayMode`); each adapter now imports them:

- **`normaliseDiscovery`** — one shared impl, was duplicated in all three adapters.
- **`normaliseCompression`** — new shared helper replacing the inline `compressionLevel`/`minBodyBytes` parsing in all three adapters. Adapters map the shared `undefined` results to `null` at their JSON/IPC boundaries exactly as before; the Node napi bridge keeps passing `undefined`.
- **`bigintToSafeNumber`** — the u64 safe-range guard, previously duplicated as Deno's `bigintToSafeNumber` and Tauri's `u64Handle` under two names, now one shared function. The Deno adapter re-exports it under its original name so test #252 keeps importing it from `src/adapter.ts`.

Closes #312

## Commit 2 — `refactor(deno): consolidate FFI chunk-read grow/retry into one readChunk (#313)`

The `iroh_http_try_next_chunk` sync-first, grow-and-retry protocol was duplicated inline in `packages/iroh-http-deno/src/adapter.ts` in two places (`makeBridge` and `DenoAdapter.nextChunk`). Extracted a single module-level `readChunk(eh, handle)` helper both call. The buffer-grow/retry semantics (sync try → grow-retry sync → async fallback → grow-retry async), `chunkBufHint` updates, and EOF/hard-error handling are preserved exactly.

Closes #313

## Verification

- `npm run ci` — **green end-to-end** (fmt, clippy, rust/tauri tests, cargo-deny, cargo-audit, npm audit, builds, typecheck, lockfile, node/deno unit tests, interop).
- Cross-runtime conformance unchanged: `node → deno` and `deno → node` both ✓.
- No version-field bumps; no build-artifact churn (index.js, deno.lock, lockfiles reverted).