### PR TITLE
fix(tauri): add path-change subscription parity (#314)

### DIFF
--- a/packages/iroh-http-tauri/build.rs
+++ b/packages/iroh-http-tauri/build.rs
@@ -51,6 +51,8 @@ fn main() {
         "mdns_advertise_close",
         // Transport / path-change events (bundled into iroh-http:default)
         "start_transport_events",
+        "next_path_change",
+        "unsubscribe_path_changes",
     ])
     .android_path("android")
     .ios_path("ios")

--- a/packages/iroh-http-tauri/guest-js/__tests__/adapter.test.ts
+++ b/packages/iroh-http-tauri/guest-js/__tests__/adapter.test.ts
@@ -211,6 +211,65 @@ describe("error propagation", () => {
   });
 });
 
+// ── path-change subscription parity (#314) ──────────────────────────────────
+
+describe("path-change subscription", () => {
+  beforeEach(() => {
+    mockWindows("main");
+  });
+
+  // Regression guard: before the Tauri adapter overrode nextPathChange /
+  // unsubscribePathChanges, pathChanges() fell through to the IrohAdapter base
+  // class and rejected with "nextPathChange() not supported by this adapter".
+  it("invokes next_path_change / unsubscribe_path_changes and completes cleanly", async () => {
+    const invoked: Array<{ cmd: string; args: unknown }> = [];
+
+    mockIPC((cmd, args) => {
+      invoked.push({ cmd, args });
+      if (cmd === "plugin:iroh-http|create_endpoint") {
+        return {
+          endpointHandle: 1,
+          nodeId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        };
+      }
+      if (cmd === "plugin:iroh-http|wait_endpoint_closed") {
+        return new Promise(() => {});
+      }
+      if (cmd === "plugin:iroh-http|node_addr") {
+        return {
+          id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          addrs: [],
+        };
+      }
+      // Subscription end — the core command returns null when the watcher
+      // stops. The iterator must then tear down via unsubscribe_path_changes.
+      if (cmd === "plugin:iroh-http|next_path_change") return null;
+      if (cmd === "plugin:iroh-http|unsubscribe_path_changes") return null;
+      if (cmd === "plugin:iroh-http|close_endpoint") return undefined;
+    });
+
+    const { createNode } = await import("../index.ts");
+    const node = await createNode({ disableNetworking: true });
+    const iterator = node
+      .pathChanges(node.publicKey)
+      [Symbol.asyncIterator]();
+    const result = await iterator.next();
+
+    expect(result.done).toBe(true);
+    const cmds = invoked.map((c) => c.cmd);
+    expect(cmds).toContain("plugin:iroh-http|next_path_change");
+    expect(cmds).toContain("plugin:iroh-http|unsubscribe_path_changes");
+    const nextCall = invoked.find(
+      (c) => c.cmd === "plugin:iroh-http|next_path_change",
+    );
+    expect((nextCall?.args as { endpointHandle?: number }).endpointHandle)
+      .toBe(1);
+    expect(
+      typeof (nextCall?.args as { nodeId?: unknown }).nodeId,
+    ).toBe("string");
+  });
+});
+
 // ── datagram base64 encode (defensive oversize guard, #288) ─────────────────
 
 describe("datagram base64 encode helper", () => {

--- a/packages/iroh-http-tauri/guest-js/index.ts
+++ b/packages/iroh-http-tauri/guest-js/index.ts
@@ -25,6 +25,7 @@ import type { RawSessionFns } from "@momics/iroh-http-shared/adapter";
 import type {
   EndpointStats,
   NodeAddrInfo,
+  PathInfo,
   PeerDiscoveryEvent,
   PeerStats,
 } from "@momics/iroh-http-shared";
@@ -380,6 +381,26 @@ class TauriAdapter extends IrohAdapter {
     }).catch((err: unknown) =>
       console.error("[iroh-http-tauri] startTransportEvents error:", err)
     );
+  }
+
+  override async nextPathChange(
+    endpointHandle: number,
+    nodeId: string,
+  ): Promise<PathInfo | null> {
+    return invoke<PathInfo | null>(`${PLUGIN}|next_path_change`, {
+      endpointHandle: Number(endpointHandle),
+      nodeId,
+    });
+  }
+
+  override async unsubscribePathChanges(
+    endpointHandle: number,
+    nodeId: string,
+  ): Promise<void> {
+    await invoke<void>(`${PLUGIN}|unsubscribe_path_changes`, {
+      endpointHandle: Number(endpointHandle),
+      nodeId,
+    });
   }
 }
 

--- a/packages/iroh-http-tauri/permissions/autogenerated/commands/next_path_change.toml
+++ b/packages/iroh-http-tauri/permissions/autogenerated/commands/next_path_change.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-next-path-change"
+description = "Enables the next_path_change command without any pre-configured scope."
+commands.allow = ["next_path_change"]
+
+[[permission]]
+identifier = "deny-next-path-change"
+description = "Denies the next_path_change command without any pre-configured scope."
+commands.deny = ["next_path_change"]

--- a/packages/iroh-http-tauri/permissions/autogenerated/commands/unsubscribe_path_changes.toml
+++ b/packages/iroh-http-tauri/permissions/autogenerated/commands/unsubscribe_path_changes.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-unsubscribe-path-changes"
+description = "Enables the unsubscribe_path_changes command without any pre-configured scope."
+commands.allow = ["unsubscribe_path_changes"]
+
+[[permission]]
+identifier = "deny-unsubscribe-path-changes"
+description = "Denies the unsubscribe_path_changes command without any pre-configured scope."
+commands.deny = ["unsubscribe_path_changes"]

--- a/packages/iroh-http-tauri/permissions/autogenerated/reference.md
+++ b/packages/iroh-http-tauri/permissions/autogenerated/reference.md
@@ -15,6 +15,8 @@ Node lifecycle and introspection. Covers createNode() and close(). Add iroh-http
 - `allow-peer-stats`
 - `allow-endpoint-stats`
 - `allow-start-transport-events`
+- `allow-next-path-change`
+- `allow-unsubscribe-path-changes`
 
 ## Permission Table
 
@@ -463,6 +465,32 @@ Enables the next_chunk command without any pre-configured scope.
 <td>
 
 Denies the next_chunk command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`iroh-http:allow-next-path-change`
+
+</td>
+<td>
+
+Enables the next_path_change command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`iroh-http:deny-next-path-change`
+
+</td>
+<td>
+
+Denies the next_path_change command without any pre-configured scope.
 
 </td>
 </tr>
@@ -1087,6 +1115,32 @@ Enables the try_next_chunk command without any pre-configured scope.
 <td>
 
 Denies the try_next_chunk command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`iroh-http:allow-unsubscribe-path-changes`
+
+</td>
+<td>
+
+Enables the unsubscribe_path_changes command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`iroh-http:deny-unsubscribe-path-changes`
+
+</td>
+<td>
+
+Denies the unsubscribe_path_changes command without any pre-configured scope.
 
 </td>
 </tr>

--- a/packages/iroh-http-tauri/permissions/default.toml
+++ b/packages/iroh-http-tauri/permissions/default.toml
@@ -14,4 +14,6 @@ permissions = [
   "allow-peer-stats",
   "allow-endpoint-stats",
   "allow-start-transport-events",
+  "allow-next-path-change",
+  "allow-unsubscribe-path-changes",
 ]

--- a/packages/iroh-http-tauri/permissions/schemas/schema.json
+++ b/packages/iroh-http-tauri/permissions/schemas/schema.json
@@ -499,6 +499,18 @@
           "markdownDescription": "Denies the next_chunk command without any pre-configured scope."
         },
         {
+          "description": "Enables the next_path_change command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-next-path-change",
+          "markdownDescription": "Enables the next_path_change command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the next_path_change command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-next-path-change",
+          "markdownDescription": "Denies the next_path_change command without any pre-configured scope."
+        },
+        {
           "description": "Enables the node_addr command without any pre-configured scope.",
           "type": "string",
           "const": "allow-node-addr",
@@ -787,6 +799,18 @@
           "markdownDescription": "Denies the try_next_chunk command without any pre-configured scope."
         },
         {
+          "description": "Enables the unsubscribe_path_changes command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-unsubscribe-path-changes",
+          "markdownDescription": "Enables the unsubscribe_path_changes command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unsubscribe_path_changes command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-unsubscribe-path-changes",
+          "markdownDescription": "Denies the unsubscribe_path_changes command without any pre-configured scope."
+        },
+        {
           "description": "Enables the wait_endpoint_closed command without any pre-configured scope.",
           "type": "string",
           "const": "allow-wait-endpoint-closed",
@@ -823,10 +847,10 @@
           "markdownDescription": "Enables low-level key operations — generate keypairs, sign with a secret key, and verify public key signatures.\n#### This permission set includes:\n\n- `allow-generate-secret-key`\n- `allow-secret-key-sign`\n- `allow-public-key-verify`"
         },
         {
-          "description": "Node lifecycle and introspection. Covers createNode() and close(). Add iroh-http:fetch and/or iroh-http:serve for HTTP capability.\n#### This default permission set includes:\n\n- `allow-create-endpoint`\n- `allow-close-endpoint`\n- `allow-wait-endpoint-closed`\n- `allow-ping`\n- `allow-node-addr`\n- `allow-node-ticket`\n- `allow-home-relay`\n- `allow-peer-info`\n- `allow-peer-stats`\n- `allow-endpoint-stats`\n- `allow-start-transport-events`",
+          "description": "Node lifecycle and introspection. Covers createNode() and close(). Add iroh-http:fetch and/or iroh-http:serve for HTTP capability.\n#### This default permission set includes:\n\n- `allow-create-endpoint`\n- `allow-close-endpoint`\n- `allow-wait-endpoint-closed`\n- `allow-ping`\n- `allow-node-addr`\n- `allow-node-ticket`\n- `allow-home-relay`\n- `allow-peer-info`\n- `allow-peer-stats`\n- `allow-endpoint-stats`\n- `allow-start-transport-events`\n- `allow-next-path-change`\n- `allow-unsubscribe-path-changes`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Node lifecycle and introspection. Covers createNode() and close(). Add iroh-http:fetch and/or iroh-http:serve for HTTP capability.\n#### This default permission set includes:\n\n- `allow-create-endpoint`\n- `allow-close-endpoint`\n- `allow-wait-endpoint-closed`\n- `allow-ping`\n- `allow-node-addr`\n- `allow-node-ticket`\n- `allow-home-relay`\n- `allow-peer-info`\n- `allow-peer-stats`\n- `allow-endpoint-stats`\n- `allow-start-transport-events`"
+          "markdownDescription": "Node lifecycle and introspection. Covers createNode() and close(). Add iroh-http:fetch and/or iroh-http:serve for HTTP capability.\n#### This default permission set includes:\n\n- `allow-create-endpoint`\n- `allow-close-endpoint`\n- `allow-wait-endpoint-closed`\n- `allow-ping`\n- `allow-node-addr`\n- `allow-node-ticket`\n- `allow-home-relay`\n- `allow-peer-info`\n- `allow-peer-stats`\n- `allow-endpoint-stats`\n- `allow-start-transport-events`\n- `allow-next-path-change`\n- `allow-unsubscribe-path-changes`"
         },
         {
           "description": "Enables node.fetch() — send HTTP requests to remote peers. Includes all internal body-streaming primitives required for fetch to function.\n#### This permission set includes:\n\n- `allow-fetch`\n- `allow-create-fetch-token`\n- `allow-cancel-in-flight`\n- `allow-cancel-request`\n- `allow-create-body-writer`\n- `allow-next-chunk`\n- `allow-try-next-chunk`\n- `allow-send-chunk`\n- `allow-finish-body`",

--- a/packages/iroh-http-tauri/src/commands.rs
+++ b/packages/iroh-http-tauri/src/commands.rs
@@ -1406,3 +1406,109 @@ pub async fn start_transport_events(
     });
     Ok(())
 }
+
+// ── Path-change subscriptions ─────────────────────────────────────────────────
+
+/// One live path-change subscription for a `(endpoint, peer)` pair.
+///
+/// Mirrors the `PathSub` used by the Node (`src/lib.rs`) and Deno
+/// (`src/dispatch.rs`) adapters: it wraps the core watcher's receiver and a
+/// `Notify` used to wake a blocked `next_path_change` when the frontend
+/// unsubscribes.
+struct PathSub {
+    rx: tokio::sync::Mutex<
+        tokio::sync::mpsc::UnboundedReceiver<iroh_http_core::endpoint::PathInfo>,
+    >,
+    notify: tokio::sync::Notify,
+}
+
+type PathRxMap =
+    std::sync::Mutex<std::collections::HashMap<(u64, String), std::sync::Arc<PathSub>>>;
+
+fn path_change_rxs() -> &'static PathRxMap {
+    static PATH_CHANGE_RXS: std::sync::OnceLock<PathRxMap> = std::sync::OnceLock::new();
+    PATH_CHANGE_RXS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Subscribe to path changes for a specific peer and return the next change.
+///
+/// Returns the next `PathInfo` as soon as the peer's active path changes, or
+/// `null` when the subscription ends (endpoint closed or `unsubscribe`).
+/// Call repeatedly to receive successive changes; the endpoint de-duplicates
+/// watcher tasks so concurrent calls for the same peer share one Rust task.
+/// Mirrors `next_path_change` in the Node and Deno adapters, wiring to
+/// `IrohEndpoint::subscribe_path_changes` in `iroh-http-core`.
+#[command]
+pub async fn next_path_change(
+    endpoint_handle: u64,
+    node_id: String,
+) -> Result<Option<iroh_http_core::endpoint::PathInfo>, String> {
+    let ep = state::get_endpoint(endpoint_handle).ok_or_else(|| {
+        format_error_json(
+            "INVALID_HANDLE",
+            format!("invalid endpoint handle: {endpoint_handle}"),
+        )
+    })?;
+
+    let key = (endpoint_handle, node_id.clone());
+    let rx_arc = {
+        let mut map = path_change_rxs()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.entry(key.clone())
+            .or_insert_with(|| {
+                let rx = ep.subscribe_path_changes(&node_id);
+                std::sync::Arc::new(PathSub {
+                    rx: tokio::sync::Mutex::new(rx),
+                    notify: tokio::sync::Notify::new(),
+                })
+            })
+            .clone()
+    };
+
+    let mut rx = rx_arc.rx.lock().await;
+    let result = tokio::select! {
+        path = rx.recv() => path,
+        () = rx_arc.notify.notified() => None,
+    };
+    match result {
+        None => {
+            drop(rx);
+            let mut map = path_change_rxs()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if map
+                .get(&key)
+                .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &rx_arc))
+            {
+                map.remove(&key);
+            }
+            Ok(None)
+        }
+        Some(path) => Ok(Some(path)),
+    }
+}
+
+/// Stop an active path-change subscription for a specific peer.
+///
+/// Wakes any blocked `next_path_change` call for the peer and tears down the
+/// core watcher. Mirrors `unsubscribe_path_changes` in the Node and Deno
+/// adapters.
+#[command]
+pub fn unsubscribe_path_changes(endpoint_handle: u64, node_id: String) -> Result<(), String> {
+    let ep = state::get_endpoint(endpoint_handle).ok_or_else(|| {
+        format_error_json(
+            "INVALID_HANDLE",
+            format!("invalid endpoint handle: {endpoint_handle}"),
+        )
+    })?;
+    if let Some(sub) = path_change_rxs()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&(endpoint_handle, node_id.clone()))
+    {
+        sub.notify.notify_waiters();
+    }
+    ep.unsubscribe_path_changes(&node_id);
+    Ok(())
+}

--- a/packages/iroh-http-tauri/src/lib.rs
+++ b/packages/iroh-http-tauri/src/lib.rs
@@ -139,6 +139,8 @@ impl<R: Runtime> PluginBuilder<R> {
             commands::session_recv_datagram,
             commands::session_max_datagram_size,
             commands::start_transport_events,
+            commands::next_path_change,
+            commands::unsubscribe_path_changes,
         ]);
 
         // Register the `httpi://` scheme protocol before `.build()` — Tauri

--- a/tests/suites/discovery.mjs
+++ b/tests/suites/discovery.mjs
@@ -34,6 +34,30 @@ export function discoveryTests({ createNode, test, assert }) {
     }
   });
 
+  // Parity guard: every adapter must implement the path-change subscription
+  // FFI (nextPathChange + unsubscribePathChanges). Before the Tauri adapter
+  // overrode these, this iteration rejected with "nextPathChange() not
+  // supported by this adapter". Aborting mid-subscription must wake the
+  // pending nextPathChange (via unsubscribePathChanges) and complete cleanly.
+  test("pathChanges() subscription resolves when aborted", async () => {
+    const node = await createNode({ disableNetworking: true });
+    try {
+      const ac = new AbortController();
+      const iterator = node
+        .pathChanges(node.publicKey, { signal: ac.signal })
+        [Symbol.asyncIterator]();
+      const pending = iterator.next();
+      ac.abort();
+      const result = await pending;
+      assert(
+        result.done === true,
+        "aborted pathChanges() iterator must complete",
+      );
+    } finally {
+      await node.close();
+    }
+  });
+
   test("advertise() resolves when signal is aborted", async () => {
     const node = await createNode();
     try {


### PR DESCRIPTION
Closes #314

## Problem
The Tauri adapter was missing `nextPathChange` / `unsubscribePathChanges`. Node and Deno implement them, but Tauri fell through to the `IrohAdapter` base class, so `pathChanges()` rejected at runtime with `nextPathChange() not supported by this adapter`, breaking the cross-runtime API-parity promise.

## Changes
- **Rust plugin commands** (`packages/iroh-http-tauri/src/commands.rs`): added `next_path_change` and `unsubscribe_path_changes`, wired to `IrohEndpoint::subscribe_path_changes` / `unsubscribe_path_changes` in `iroh-http-core` — mirroring the Node (`src/lib.rs`) and Deno (`src/dispatch.rs`) adapters (same `PathSub` + `Notify` wake-on-unsubscribe pattern). Registered in the plugin builder (`lib.rs`), `build.rs`, and granted in the default permission set (`permissions/default.toml`, plus regenerated autogenerated files).
- **JS binding** (`guest-js/index.ts`): overrode `nextPathChange` / `unsubscribePathChanges` using `invoke(...)`, mirroring the existing transport/mDNS methods.
- **Conformance coverage**: added a path-change parity test to the shared discovery suite (runs on Node/Deno/Tauri) and a Tauri guest-js IPC test asserting the new commands are invoked and the iterator completes cleanly.

## Verification
`npm run ci` is green end-to-end, including `cargo clippy --manifest-path packages/iroh-http-tauri/Cargo.toml -- -D warnings ...`, the Tauri Rust tests (incl. the command-list/permission integrity tests), the Tauri guest-js vitest suite, and Node/Deno/interop suites.

No version-field bumps; build-artifact churn (`index.js`, `deno.lock`, `package-lock.json`) reverted.