### PR TITLE
refactor(adapter): unify request-delivery seam behind RequestTransport (#315)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ version = "0.5.2"
 dependencies = [
  "iroh-http-core",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/iroh-http-adapter/Cargo.toml
+++ b/crates/iroh-http-adapter/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 [dependencies]
 iroh-http-core = { path = "../iroh-http-core", version = "0.5.2" }
 serde_json = "1"
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/iroh-http-adapter/src/lib.rs
+++ b/crates/iroh-http-adapter/src/lib.rs
@@ -8,7 +8,9 @@
 //! an adapter-layer concern, not HTTP transport semantics.
 #![deny(unsafe_code)]
 
-use iroh_http_core::{respond, CoreError, ErrorCode, HandleStore, ResponseHeadEntry};
+use iroh_http_core::{
+    respond, CoreError, ErrorCode, HandleStore, RequestPayload, ResponseHeadEntry,
+};
 
 /// Maximum number of header rows accepted at an adapter boundary.
 pub const MAX_HEADER_COUNT: usize = 100;
@@ -60,6 +62,117 @@ pub fn send_undeliverable_rejection(
 ) -> Result<(), CoreError> {
     let head = reject_undeliverable(reason);
     respond(handles, req_handle, head.status, head.headers)
+}
+
+// ── Request-delivery seam (#315) ────────────────────────────────────────────
+//
+// Core (`FfiDispatcher::dispatch`) acquires the request-body reader / response-
+// body writer, measures header bytes, and fires `on_request` with a
+// `RequestPayload`. The only parts previously duplicated across the three
+// bridges were (1) the header reshape into `Vec<Vec<String>>` and (2) the
+// undeliverable fallback. `deliver_request` owns both, leaving each bridge with
+// only its genuinely runtime-specific byte transport behind `RequestTransport`.
+
+/// A request reshaped once for delivery to a JS/TS runtime.
+///
+/// Built from a core [`RequestPayload`] by [`DeliverableRequest::from_payload`],
+/// which performs the single header reshape (`(k, v)` pairs → `[k, v]` rows)
+/// that each bridge used to do itself.
+#[derive(Debug, Clone)]
+pub struct DeliverableRequest {
+    /// Response-head slot handle (see [`RequestPayload::req_handle`]).
+    pub req_handle: u64,
+    /// Inbound request-body reader handle (`0` = no request body).
+    pub req_body_handle: u64,
+    /// Outbound response-body writer handle (`0` = body already closed).
+    pub res_body_handle: u64,
+    /// Whether this is a bidirectional (`is_bidi`) stream.
+    pub is_bidi: bool,
+    /// HTTP request method.
+    pub method: String,
+    /// Full `httpi://` request URL.
+    pub url: String,
+    /// Request headers as `[[name, value], ...]`, reshaped exactly once.
+    pub headers: Vec<Vec<String>>,
+    /// Base32 node id of the remote peer that sent the request.
+    pub remote_node_id: String,
+}
+
+impl DeliverableRequest {
+    /// Reshape a core [`RequestPayload`] into a [`DeliverableRequest`].
+    ///
+    /// This is the single place the `(name, value)` header pairs are reshaped
+    /// into `[name, value]` rows for the JS/TS boundary.
+    pub fn from_payload(payload: RequestPayload) -> Self {
+        Self {
+            req_handle: payload.req_handle,
+            req_body_handle: payload.req_body_handle,
+            res_body_handle: payload.res_body_handle,
+            is_bidi: payload.is_bidi,
+            method: payload.method,
+            url: payload.url,
+            headers: payload
+                .headers
+                .into_iter()
+                .map(|(k, v)| vec![k, v])
+                .collect(),
+            remote_node_id: payload.remote_node_id,
+        }
+    }
+}
+
+/// Signals that a request could not be handed to the runtime handler.
+///
+/// `reason` carries stable context for logs and the undeliverable rejection.
+#[derive(Debug, Clone)]
+pub struct Undeliverable {
+    /// Human-readable reason the request could not be delivered.
+    pub reason: String,
+}
+
+impl Undeliverable {
+    /// Build an [`Undeliverable`] from any displayable reason.
+    pub fn new(reason: impl std::fmt::Display) -> Self {
+        Self {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+/// The per-runtime byte transport that hands a request to the JS/TS handler.
+///
+/// This is the only per-adapter surface: Node wraps a `ThreadsafeFunction`,
+/// Deno the serve-registry mpsc queue, Tauri a `Channel`. Each maps its native
+/// send failure (and, for Deno, registry-miss / shutdown / queue-full
+/// reachability gating) to [`Undeliverable`]. Implementations must be `T`, not
+/// `dyn`, so the delivery path stays monomorphised and `#![deny(unsafe_code)]`
+/// clean.
+pub trait RequestTransport {
+    /// Attempt to deliver `req` to the runtime handler.
+    ///
+    /// Returns `Err(Undeliverable)` if the request cannot reach the handler;
+    /// [`deliver_request`] then performs the shared fail-closed cleanup.
+    fn deliver(&self, req: &DeliverableRequest) -> Result<(), Undeliverable>;
+}
+
+/// Reshape a request once, deliver it through `transport`, and on failure emit
+/// the fail-closed 503 rejection **and** finish the response body writer.
+///
+/// Finishing the response body is essential: core builds the response body from
+/// a reader that yields until the writer is finished/dropped, so an
+/// undeliverable request that only sent the rejection head would hang until the
+/// drain timeout. Both cleanup steps run exactly once and their errors are
+/// ignored (the request head/body may already be gone).
+pub fn deliver_request<T: RequestTransport>(
+    handles: &HandleStore,
+    transport: &T,
+    payload: RequestPayload,
+) {
+    let req = DeliverableRequest::from_payload(payload);
+    if let Err(undeliverable) = transport.deliver(&req) {
+        let _ = send_undeliverable_rejection(handles, req.req_handle, &undeliverable.reason);
+        let _ = handles.finish_body(req.res_body_handle);
+    }
 }
 
 /// Adapter-boundary input validation error.
@@ -495,7 +608,89 @@ pub fn format_error_json(code: &str, msg: impl std::fmt::Display) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iroh_http_core::CoreError;
+    use iroh_http_core::{CoreError, HandleStore, RequestPayload, StoreConfig};
+
+    /// Transport that always rejects, mirroring a runtime that can never be
+    /// reached. Used to exercise the shared undeliverable path.
+    struct MockTransport;
+
+    impl RequestTransport for MockTransport {
+        fn deliver(&self, _req: &DeliverableRequest) -> Result<(), Undeliverable> {
+            Err(Undeliverable::new("mock transport is always undeliverable"))
+        }
+    }
+
+    // Regression + conformance guard for #315: on the undeliverable path the
+    // shared delivery must (i) send the 503 + `content-length: 0` head and
+    // (ii) finish the response body writer so the client closes immediately
+    // instead of hanging until the drain timeout.
+    #[test]
+    fn deliver_request_undeliverable_rejects_and_finishes_body() {
+        let store = HandleStore::new(StoreConfig::default());
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        let req_handle = store.allocate_req_handle(tx).unwrap();
+        let (writer, _reader) = store.make_body_channel();
+        let res_body_handle = store.insert_writer(writer).unwrap();
+
+        let (_, writers_before, _, _) = store.count_handles();
+        assert_eq!(writers_before, 1, "test setup should register one writer");
+
+        let payload = RequestPayload {
+            req_handle,
+            req_body_handle: 0,
+            res_body_handle,
+            method: "GET".to_string(),
+            url: "httpi://test/".to_string(),
+            headers: vec![("x-a".to_string(), "1".to_string())],
+            remote_node_id: "peer".to_string(),
+            is_bidi: false,
+        };
+
+        deliver_request(&store, &MockTransport, payload);
+
+        let expected = reject_undeliverable("conformance");
+        let head = rx
+            .try_recv()
+            .expect("undeliverable request should receive an immediate response head");
+        assert_eq!(head.status, expected.status);
+        assert_eq!(head.headers, expected.headers);
+
+        let (_, writers_after, _, _) = store.count_handles();
+        assert_eq!(
+            writers_after, 0,
+            "response body writer must be finished on the undeliverable path"
+        );
+    }
+
+    #[test]
+    fn deliverable_request_reshapes_headers_once() {
+        let payload = RequestPayload {
+            req_handle: 1,
+            req_body_handle: 2,
+            res_body_handle: 3,
+            method: "POST".to_string(),
+            url: "httpi://test/x".to_string(),
+            headers: vec![
+                ("a".to_string(), "1".to_string()),
+                ("b".to_string(), "2".to_string()),
+            ],
+            remote_node_id: "peer".to_string(),
+            is_bidi: true,
+        };
+        let req = DeliverableRequest::from_payload(payload);
+        assert_eq!(req.req_handle, 1);
+        assert_eq!(req.req_body_handle, 2);
+        assert_eq!(req.res_body_handle, 3);
+        assert!(req.is_bidi);
+        assert_eq!(req.method, "POST");
+        assert_eq!(
+            req.headers,
+            vec![
+                vec!["a".to_string(), "1".to_string()],
+                vec!["b".to_string(), "2".to_string()],
+            ]
+        );
+    }
 
     #[test]
     fn core_error_to_json_timeout() {

--- a/docs/adr/009-ffi-bridge-reliability.md
+++ b/docs/adr/009-ffi-bridge-reliability.md
@@ -1,13 +1,61 @@
 ---
 id: "009"
 title: "FFI bridge reliability under concurrent load"
-status: open
+status: accepted
 date: 2026-04-25
 area: ffi | transport
 tags: [ffi, deno, node, tauri, concurrency, race-condition, backpressure]
 ---
 
 # [009] FFI bridge reliability under concurrent load
+
+## Decision
+
+The `#119`/`#122`/`#123` stale-handle race class this exploration opened
+against has since been **closed in core**, not at the bridges:
+
+- **Option A (oneshot acknowledgment)** landed as the response-head oneshot
+  rendezvous in `FfiDispatcher::dispatch`
+  (`crates/iroh-http-core/src/ffi/dispatcher.rs`): the request task hands the
+  head slot to JS and awaits `respond()` before proceeding, so the handle
+  cannot be freed inside the timing window.
+- **Option C (ownership tokens)** landed as `ReqHeadGuard` + the `InsertGuard`
+  multi-handle allocation guards in `crates/iroh-http-core/src/ffi/handles.rs`,
+  which roll back partially-allocated handles on every dispatch exit path.
+
+With the race class closed in core, the remaining decision is about **code
+shape, not reliability**: the request-delivery preamble each bridge ran before
+handing a request to its runtime was partly duplicated (the header reshape into
+`Vec<Vec<String>>` and the fail-closed undeliverable fallback). That preamble
+is now lifted into `iroh-http-adapter` behind a `RequestTransport` trait
+(`deliver_request` + `DeliverableRequest` + `Undeliverable`, see
+[#315](https://github.com/Momics/iroh-http/issues/315)). Each bridge keeps only
+its genuinely runtime-specific byte transport:
+
+| Adapter | `RequestTransport` impl | Native failure mapped to `Undeliverable` |
+|---------|-------------------------|------------------------------------------|
+| Node    | `NodeTransport`  | `ThreadsafeFunction` enqueue status ≠ `Ok` |
+| Deno    | `DenoTransport`  | registry miss / serve shutdown / queue full |
+| Tauri   | `TauriTransport` | `Channel::send` error |
+
+This is **additive and non-breaking** per
+[005 — FFI versioning](005-ffi-versioning-compatibility.md): the seam lives
+entirely inside the adapter layer, which is internal and co-versioned with core.
+There is no JS-visible contract change — the concern raised below that "a
+callback contract change is a breaking FFI change" does not apply because the
+core `on_request` callback shape is unchanged.
+
+Folding the undeliverable fallback into the shared path also fixed a
+released-behaviour bug: on the undeliverable-503 path Node and Deno sent the
+rejection head but never finished the response body writer, so the client hung
+until the drain timeout. `deliver_request` now finishes the writer on every
+undeliverable path (regression guarded by
+`deno_delivery_undeliverable_finishes_response_body` and the shared
+`MockTransport` conformance test).
+
+Scope: unary request delivery only. Bidirectional streaming uses the separate
+session-stream API (`Session::create_bidi_stream` / `next_bidi_stream`), which
+does not run the delivery preamble and is out of scope here.
 
 ## Context
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,16 @@ Core's `serve()` accepts an `on_request: Arc<dyn Fn(RequestPayload) + Send + Syn
 
 Each adapter is responsible for surfacing errors from its callback mechanism. The core does not observe whether the callback succeeded.
 
+#### Request-delivery seam (`RequestTransport`)
+
+The shared part of each adapter's `on_request` closure lives once in `iroh-http-adapter` behind the `RequestTransport` seam (ADR-009, #315). Core already acquires the request-body reader / response-body writer, measures header bytes, and fires `on_request` with a `RequestPayload`; the only parts that were duplicated across the three bridges — the header reshape into `Vec<Vec<String>>` and the fail-closed undeliverable fallback — are owned by the adapter:
+
+- `DeliverableRequest::from_payload` performs the single header reshape.
+- `RequestTransport::deliver(&DeliverableRequest) -> Result<(), Undeliverable>` is the **only** per-adapter surface. Each bridge maps its native send failure (Node `ThreadsafeFunction` enqueue status; Deno registry-miss / shutdown / queue-full; Tauri `Channel::send`) to `Undeliverable`. It is a generic bound (`T`, monomorphised), not `dyn`, so `#![deny(unsafe_code)]` stays clean.
+- `deliver_request<T>(handles, transport, payload)` reshapes once, delivers, and on `Err` emits the 503 rejection **and** finishes the response body writer exactly once. Finishing the writer is required: core builds the response body from a reader that yields until the writer is finished/dropped, so an undeliverable request that only sent the rejection head would hang until the drain timeout.
+
+Each bridge's `on_request` closure therefore collapses to a single `deliver_request(...)` call. The seam covers **unary** request delivery only; bidirectional streaming uses the separate session-stream API (`Session::create_bidi_stream` / `next_bidi_stream`).
+
 ### iroh-http-shared (TypeScript)
 
 Shared TypeScript layer consumed by all JS/TS adapters:

--- a/packages/iroh-http-deno/src/dispatch.rs
+++ b/packages/iroh-http-deno/src/dispatch.rs
@@ -70,8 +70,9 @@ fn insert_endpoint(ep: IrohEndpoint) -> u64 {
 
 use iroh_http_adapter::{
     coerce_endpoint_options, coerce_fetch_options, coerce_serve_options, core_error_to_json,
-    format_error_json, send_undeliverable_rejection, validate_header_rows, AdapterInputError,
-    RawEndpointOptions, RawFetchOptions, RawServeOptions,
+    deliver_request, format_error_json, send_undeliverable_rejection, validate_header_rows,
+    AdapterInputError, DeliverableRequest, RawEndpointOptions, RawFetchOptions, RawServeOptions,
+    RequestTransport, Undeliverable,
 };
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -96,48 +97,56 @@ fn err_adapter(e: AdapterInputError) -> Value {
     err_code(e.code(), e.message())
 }
 
-fn deliver_request_to_queue(handle: u64, ep: &IrohEndpoint, payload: RequestPayload) {
-    // #122: Look up the CURRENT queue from the registry instead of a captured
-    // Arc.  When serve is restarted (stopServe → serveStart), old QUIC
-    // connections may still be alive (connection pool reuse). Requests on
-    // those old connections must be delivered to the NEW queue, not the old
-    // (removed) one.
-    let req_handle = payload.req_handle;
-    let q = match serve_registry::get(handle) {
-        Some(q) => q,
-        None => {
-            tracing::warn!("iroh-http-deno: serve registry miss — responding 503");
-            let _ = send_undeliverable_rejection(ep.handles(), req_handle, "deno registry miss");
-            return;
+/// Deno request transport: enqueues each request onto the serve-registry mpsc
+/// queue polled by the Deno event loop. Registry-miss, serve-shutdown, and
+/// queue-full are Deno-local transport-reachability failures mapped to
+/// [`Undeliverable`]; [`deliver_request`] then sends the fail-closed 503 and
+/// finishes the response body (the latter fixes the pre-#315 hang).
+struct DenoTransport {
+    handle: u64,
+}
+
+impl RequestTransport for DenoTransport {
+    fn deliver(&self, req: &DeliverableRequest) -> Result<(), Undeliverable> {
+        // #122: Look up the CURRENT queue from the registry instead of a
+        // captured Arc. When serve is restarted (stopServe → serveStart), old
+        // QUIC connections may still be alive (connection pool reuse). Requests
+        // on those old connections must be delivered to the NEW queue, not the
+        // old (removed) one.
+        let q = match serve_registry::get(self.handle) {
+            Some(q) => q,
+            None => {
+                tracing::warn!("iroh-http-deno: serve registry miss — responding 503");
+                return Err(Undeliverable::new("deno registry miss"));
+            }
+        };
+        // #149: Reject immediately if this queue belongs to a stopped serve
+        // cycle. The queue stays in the registry between stopServe and the next
+        // serveStart so the request never hangs until the tower timeout.
+        if *q.shutdown_rx.borrow() {
+            tracing::warn!("iroh-http-deno: serve shutdown — responding 503");
+            return Err(Undeliverable::new("deno serve shutdown"));
         }
-    };
-    // #149: Reject immediately if this queue belongs to a stopped serve cycle.
-    // The queue stays in the registry between stopServe and the next serveStart
-    // so the request never hangs until the tower timeout.
-    if *q.shutdown_rx.borrow() {
-        tracing::warn!("iroh-http-deno: serve shutdown — responding 503");
-        let _ = send_undeliverable_rejection(ep.handles(), req_handle, "deno serve shutdown");
-        return;
+        let event = serde_json::json!({
+            "reqHandle":         req.req_handle,
+            "reqBodyHandle":     req.req_body_handle,
+            "resBodyHandle":     req.res_body_handle,
+            "isBidi":            req.is_bidi,
+            "method":            req.method,
+            "url":               req.url,
+            "headers":           req.headers,
+            "remoteNodeId":      req.remote_node_id,
+        });
+        if q.tx.try_send(event).is_err() {
+            tracing::warn!("iroh-http-deno: serve queue full — dropping request with 503");
+            return Err(Undeliverable::new("deno serve queue full"));
+        }
+        Ok(())
     }
-    let headers: Vec<Vec<String>> = payload
-        .headers
-        .into_iter()
-        .map(|(k, v)| vec![k, v])
-        .collect();
-    let event = serde_json::json!({
-        "reqHandle":         payload.req_handle,
-        "reqBodyHandle":     payload.req_body_handle,
-        "resBodyHandle":     payload.res_body_handle,
-        "isBidi":            payload.is_bidi,
-        "method":            payload.method,
-        "url":               payload.url,
-        "headers":           headers,
-        "remoteNodeId":      payload.remote_node_id,
-    });
-    if q.tx.try_send(event).is_err() {
-        tracing::warn!("iroh-http-deno: serve queue full — dropping request with 503");
-        let _ = send_undeliverable_rejection(ep.handles(), req_handle, "deno serve queue full");
-    }
+}
+
+fn deliver_request_to_queue(handle: u64, ep: &IrohEndpoint, payload: RequestPayload) {
+    deliver_request(ep.handles(), &DenoTransport { handle }, payload);
 }
 
 /// Extract and look up the endpoint from a JSON payload's `endpointHandle`.

--- a/packages/iroh-http-deno/src/dispatch.rs
+++ b/packages/iroh-http-deno/src/dispatch.rs
@@ -1642,10 +1642,55 @@ mod tests {
         assert_eq!(head.headers, expected.headers);
     }
 
+    fn pending_payload_with_res_body(
+        ep: &IrohEndpoint,
+    ) -> (RequestPayload, oneshot::Receiver<ResponseHeadEntry>) {
+        let (tx, rx) = oneshot::channel();
+        let req_handle = ep.handles().allocate_req_handle(tx).unwrap();
+        let (writer, _reader) = ep.handles().make_body_channel();
+        let res_body_handle = ep.handles().insert_writer(writer).unwrap();
+        (
+            RequestPayload {
+                req_handle,
+                req_body_handle: 0,
+                res_body_handle,
+                method: "GET".to_string(),
+                url: "httpi://test/".to_string(),
+                headers: Vec::new(),
+                remote_node_id: "peer".to_string(),
+                is_bidi: false,
+            },
+            rx,
+        )
+    }
+
     async fn cleanup(handle: u64, ep: IrohEndpoint) {
         serve_registry::remove(handle);
         let _ = remove_endpoint(handle);
         ep.close_force().await;
+    }
+
+    // Regression: #315 — on the undeliverable-503 path Deno (and Node) left the
+    // response body writer open, so `Body::new(res_body_reader)` yielded until
+    // the drain timeout instead of closing immediately. The delivery path must
+    // finish the response body writer when a request cannot be delivered.
+    #[tokio::test]
+    async fn deno_delivery_undeliverable_finishes_response_body() {
+        let (handle, ep) = test_endpoint().await;
+        let (payload, rx) = pending_payload_with_res_body(&ep);
+        let (_, writers_before, _, _) = ep.handles().count_handles();
+        assert_eq!(writers_before, 1, "test setup should register one writer");
+
+        // Registry miss: the request is undeliverable.
+        deliver_request_to_queue(handle, &ep, payload);
+
+        assert_undeliverable(rx);
+        let (_, writers_after, _, _) = ep.handles().count_handles();
+        assert_eq!(
+            writers_after, 0,
+            "response body writer must be finished on the undeliverable path"
+        );
+        cleanup(handle, ep).await;
     }
 
     #[tokio::test]

--- a/packages/iroh-http-node/src/lib.rs
+++ b/packages/iroh-http-node/src/lib.rs
@@ -65,8 +65,9 @@ use tokio::sync::Mutex as TokioMutex;
 
 use iroh_http_adapter::{
     coerce_endpoint_options, coerce_fetch_options, coerce_serve_options, core_error_to_json,
-    format_error_json, send_undeliverable_rejection, validate_direct_addrs, validate_header_rows,
-    validate_node_id, AdapterInputError, RawEndpointOptions, RawFetchOptions, RawServeOptions,
+    deliver_request, format_error_json, validate_direct_addrs, validate_header_rows,
+    validate_node_id, AdapterInputError, DeliverableRequest, RawEndpointOptions, RawFetchOptions,
+    RawServeOptions, RequestTransport, Undeliverable,
 };
 
 struct PathSub {
@@ -711,6 +712,50 @@ pub struct JsConnectionEvent {
     pub connected: bool,
 }
 
+/// Node request transport: enqueues each request onto the JS thread via a
+/// `ThreadsafeFunction`. A non-`Ok` enqueue status means the JS handler will
+/// never see the request, which [`deliver_request`] turns into a fail-closed
+/// 503 (and finishes the response body so the client doesn't hang — ISS-019 /
+/// #315).
+struct NodeTransport {
+    tsfn: Arc<ThreadsafeFunction<JsCallArgs, (), JsCallArgs, Status, false>>,
+}
+
+impl RequestTransport for NodeTransport {
+    fn deliver(&self, req: &DeliverableRequest) -> std::result::Result<(), Undeliverable> {
+        let js_args = JsCallArgs {
+            req_handle: BigInt {
+                sign_bit: false,
+                words: vec![req.req_handle],
+            },
+            req_body_handle: BigInt {
+                sign_bit: false,
+                words: vec![req.req_body_handle],
+            },
+            res_body_handle: BigInt {
+                sign_bit: false,
+                words: vec![req.res_body_handle],
+            },
+            is_bidi: req.is_bidi,
+            method: req.method.clone(),
+            url: req.url.clone(),
+            remote_node_id: req.remote_node_id.clone(),
+            headers: req.headers.clone(),
+        };
+        let status = self
+            .tsfn
+            .call(js_args, ThreadsafeFunctionCallMode::NonBlocking);
+        if status == napi::Status::Ok {
+            Ok(())
+        } else {
+            tracing::warn!("iroh-http-node: TSFN enqueue failed ({status:?}), responding 503");
+            Err(Undeliverable::new(format!(
+                "node TSFN enqueue failed: {status:?}"
+            )))
+        }
+    }
+}
+
 /// Register a push callback for transport-level events.
 ///
 /// Spawns a Tokio task that drains the endpoint's event channel and calls
@@ -1112,47 +1157,12 @@ pub async fn raw_serve(
         });
 
     let ep_clone = ep.clone();
+    let transport = NodeTransport { tsfn };
     let handle = iroh_http_core::ffi_serve_with_callback(
         ep.clone(),
         serve_opts,
         move |payload: RequestPayload| {
-            let tsfn = Arc::clone(&tsfn);
-            let ep_ref = ep_clone.clone();
-            let req_handle = payload.req_handle;
-            let js_args = JsCallArgs {
-                req_handle: BigInt {
-                    sign_bit: false,
-                    words: vec![payload.req_handle],
-                },
-                req_body_handle: BigInt {
-                    sign_bit: false,
-                    words: vec![payload.req_body_handle],
-                },
-                res_body_handle: BigInt {
-                    sign_bit: false,
-                    words: vec![payload.res_body_handle],
-                },
-                is_bidi: payload.is_bidi,
-                method: payload.method,
-                url: payload.url,
-                remote_node_id: payload.remote_node_id,
-                headers: payload
-                    .headers
-                    .into_iter()
-                    .map(|(k, v)| vec![k, v])
-                    .collect(),
-            };
-            // ISS-019: check TSFN enqueue status; on failure respond with 503
-            // immediately so the request doesn't stall until timeout.
-            let status = tsfn.call(js_args, ThreadsafeFunctionCallMode::NonBlocking);
-            if status != napi::Status::Ok {
-                tracing::warn!("iroh-http-node: TSFN enqueue failed ({status:?}), responding 503");
-                let _ = send_undeliverable_rejection(
-                    ep_ref.handles(),
-                    req_handle,
-                    format_args!("node TSFN enqueue failed: {status:?}"),
-                );
-            }
+            deliver_request(ep_clone.handles(), &transport, payload);
         },
         conn_event_fn,
     );

--- a/packages/iroh-http-tauri/src/commands.rs
+++ b/packages/iroh-http-tauri/src/commands.rs
@@ -15,8 +15,8 @@ use crate::state;
 
 use iroh_http_adapter::{
     coerce_endpoint_options, coerce_fetch_options, coerce_serve_options, core_error_to_json,
-    format_error_json, send_undeliverable_rejection, validate_header_rows, RawEndpointOptions,
-    RawFetchOptions, RawServeOptions,
+    deliver_request, format_error_json, validate_header_rows, DeliverableRequest, RawEndpointOptions,
+    RawFetchOptions, RawServeOptions, RequestTransport, Undeliverable,
 };
 
 // ── Endpoint ──────────────────────────────────────────────────────────────────
@@ -566,6 +566,32 @@ pub struct ServeEventPayload {
     pub remote_node_id: String,
 }
 
+/// Tauri request transport: hands each request to the frontend over an IPC
+/// [`Channel`]. A `send` failure means the frontend will never see the request,
+/// which [`deliver_request`] turns into the fail-closed 503.
+struct TauriTransport {
+    channel: Channel<ServeEventPayload>,
+}
+
+impl RequestTransport for TauriTransport {
+    fn deliver(&self, req: &DeliverableRequest) -> Result<(), Undeliverable> {
+        let event = ServeEventPayload {
+            req_handle: req.req_handle,
+            req_body_handle: req.req_body_handle,
+            res_body_handle: req.res_body_handle,
+            is_bidi: req.is_bidi,
+            method: req.method.clone(),
+            url: req.url.clone(),
+            headers: req.headers.clone(),
+            remote_node_id: req.remote_node_id.clone(),
+        };
+        self.channel.send(event).map_err(|e| {
+            tracing::warn!("iroh-http-tauri: channel send error: {e}; responding 503");
+            Undeliverable::new(format!("tauri channel send failed: {e}"))
+        })
+    }
+}
+
 /// Server-side configuration passed at `serve()` time.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -629,40 +655,13 @@ pub async fn serve(
     // Clone ep so the request-dispatch closure can close orphaned requests on
     // channel failure without capturing the outer ep.
     let ep_for_closure = ep.clone();
+    let transport = TauriTransport { channel };
 
     let handle = iroh_http_core::ffi_serve_with_callback(
         ep.clone(),
         serve_opts,
         move |payload: RequestPayload| {
-            let ch = channel.clone();
-            let req_handle = payload.req_handle;
-            let res_body_handle = payload.res_body_handle;
-            let headers: Vec<Vec<String>> = payload
-                .headers
-                .into_iter()
-                .map(|(k, v)| vec![k, v])
-                .collect();
-            let event = ServeEventPayload {
-                req_handle,
-                req_body_handle: payload.req_body_handle,
-                res_body_handle,
-                is_bidi: payload.is_bidi,
-                method: payload.method,
-                url: payload.url,
-                headers,
-                remote_node_id: payload.remote_node_id,
-            };
-            if let Err(e) = ch.send(event) {
-                tracing::warn!("iroh-http-tauri: channel send error: {e}; responding 503");
-                // The JS side will never see this request — close it fail-closed so
-                // the client receives a 503 instead of a hung connection.
-                let _ = send_undeliverable_rejection(
-                    ep_for_closure.handles(),
-                    req_handle,
-                    format_args!("tauri channel send failed: {e}"),
-                );
-                let _ = ep_for_closure.handles().finish_body(res_body_handle);
-            }
+            deliver_request(ep_for_closure.handles(), &transport, payload);
         },
         conn_event_fn,
     );


### PR DESCRIPTION
Closes #315

## Summary

Lifts the shared request-delivery preamble that each JS/TS bridge ran in its `on_request` closure into `iroh-http-adapter` behind a `RequestTransport` trait. Additive and non-breaking — no core→adapter FFI contract change.

Also fixes a released-behavior bug: on the undeliverable-503 path, Node and Deno sent the fail-closed rejection head but never finished the response body writer, so those 503s hung until the drain timeout (Tauri already finished the body). The shared path now finishes the writer on every undeliverable path.

## Seam (`crates/iroh-http-adapter/src/lib.rs`)

- `DeliverableRequest::from_payload` — the single header reshape (`(k,v)` pairs → `[k,v]` rows).
- `Undeliverable { reason }`.
- `trait RequestTransport { fn deliver(&self, &DeliverableRequest) -> Result<(), Undeliverable>; }` — the only per-adapter surface (generic `T`, not `dyn`, so `#![deny(unsafe_code)]` stays clean).
- `deliver_request<T>(handles, transport, payload)` — reshape once, deliver, and on `Err` emit the 503 rejection **and** `finish_body` exactly once.

Each bridge's `on_request` closure collapses to a single `deliver_request(...)` call:

| Adapter | impl | native failure → `Undeliverable` |
|---|---|---|
| Node | `NodeTransport` | `ThreadsafeFunction` enqueue status ≠ `Ok` |
| Deno | `DenoTransport` | registry-miss / serve-shutdown / queue-full |
| Tauri | `TauriTransport` | `Channel::send` error |

## Commits (one per slice)

- `test(deno)` — failing regression for the undeliverable response-body hang.
- `refactor(adapter)` — the seam + shared `MockTransport` conformance test (503 + `content-length: 0` + body finished).
- `refactor(tauri)` — `TauriTransport` (zero behavior change; safe canary).
- `refactor(node)` — `NodeTransport` (adds the missing `finish_body`).
- `refactor(deno)` — `DenoTransport` preserving registry/shutdown/queue gating (adds the missing `finish_body`; makes the regression test pass).
- `docs(adr)` — ADR-009 → accepted (reframed) + seam documented in `architecture.md`.

## Verification

- Regression test `deno_delivery_undeliverable_finishes_response_body` **fails before** the fix (writer left open), **passes after**.
- `npm run ci` green end-to-end (fmt, clippy `-D warnings` incl. tauri, `cargo test` adapter/core/tauri, typecheck, node/deno/interop conformance).
- #119/#122 32-stream burst × 5 iterations regression passes — no timing regression.

## Scope

Unary request delivery only (the three cited closures). Bidirectional streaming uses the separate session-stream API (`Session::create_bidi_stream` / `next_bidi_stream`), which does not run the delivery preamble — no separate bidi delivery site exists.