### PR TITLE
fix(tauri): mobile mDNS browse falls back to instance name for node-id (#318)

### DIFF
--- a/packages/iroh-http-tauri/android/src/main/java/com/iroh/http/IrohHttpPlugin.kt
+++ b/packages/iroh-http-tauri/android/src/main/java/com/iroh/http/IrohHttpPlugin.kt
@@ -68,6 +68,21 @@ class IrohHttpPlugin(private val activity: Activity) : Plugin(activity) {
     private fun nsd(): NsdManager? =
         activity.getSystemService(Context.NSD_SERVICE) as? NsdManager
 
+    /**
+     * Validate that a string is a canonical iroh endpoint id: a 32-byte Ed25519
+     * public key encoded as lowercase RFC 4648 base32 without padding, i.e.
+     * exactly 52 characters drawn from the `a-z` / `2-7` alphabet.
+     *
+     * Used to safely accept the DNS-SD instance name as the node-id when a
+     * desktop advertiser emits no `pk` attribute (issue #318). The advertise
+     * side truncates instance names to 63 chars, which does not truncate a
+     * 52-char id, so the recovered id is always complete.
+     */
+    private fun isValidEndpointId(s: String): Boolean {
+        if (s.length != 52) return false
+        return s.all { c -> c in 'a'..'z' || c in '2'..'7' }
+    }
+
     // ── Browse ────────────────────────────────────────────────────────────────
 
     @Command
@@ -89,14 +104,22 @@ class IrohHttpPlugin(private val activity: Activity) : Plugin(activity) {
                 val session = browseMap[browseId] ?: return
                 manager.resolveService(serviceInfo, object : NsdManager.ResolveListener {
                     override fun onServiceResolved(resolved: NsdServiceInfo) {
-                        val pk = resolved.attributes["pk"]?.let { String(it) }
-                            ?: return
-                        if (pk.isEmpty()) return
+                        // Prefer the `pk` attribute (set by mobile advertisers);
+                        // fall back to the DNS-SD instance name for desktop
+                        // advertisers, which publish the base32 endpoint id there
+                        // and emit no `pk` attribute (issue #318).
+                        val pkAttr = resolved.attributes["pk"]?.let { String(it) }
+                        val nodeId = if (!pkAttr.isNullOrEmpty()) {
+                            pkAttr
+                        } else {
+                            val name = resolved.serviceName
+                            if (isValidEndpointId(name)) name else return
+                        }
 
                         val key = resolved.serviceName
-                        if (session.knownNodes[key] == pk) return
+                        if (session.knownNodes[key] == nodeId) return
 
-                        session.knownNodes[key] = pk
+                        session.knownNodes[key] = nodeId
                         val addrs = JSONArray()
                         resolved.attributes["relay"]?.let { b ->
                             val relay = String(b)
@@ -105,7 +128,7 @@ class IrohHttpPlugin(private val activity: Activity) : Plugin(activity) {
 
                         val event = JSObject()
                         event.put("type", "discovered")
-                        event.put("nodeId", pk)
+                        event.put("nodeId", nodeId)
                         event.put("addrs", addrs)
                         synchronized(session.pendingEvents) { session.pendingEvents.add(event) }
                     }

--- a/packages/iroh-http-tauri/ios/Sources/IrohHttpPlugin.swift
+++ b/packages/iroh-http-tauri/ios/Sources/IrohHttpPlugin.swift
@@ -105,6 +105,21 @@ class IrohHttpPlugin: Plugin {
         return result
     }
 
+    /// Validate that a string is a canonical iroh endpoint id: a 32-byte
+    /// Ed25519 public key encoded as lowercase RFC 4648 base32 without padding,
+    /// i.e. exactly 52 characters drawn from the `a-z` / `2-7` alphabet.
+    ///
+    /// Used to safely accept the DNS-SD instance name as the node-id when a
+    /// desktop advertiser emits no `pk` TXT (issue #318). The advertise side
+    /// truncates instance names to 63 chars, which does not truncate a 52-char
+    /// id, so the recovered id is always complete.
+    private func isValidEndpointId(_ s: String) -> Bool {
+        guard s.count == 52 else { return false }
+        return s.allSatisfy { c in
+            (c >= "a" && c <= "z") || (c >= "2" && c <= "7")
+        }
+    }
+
     // MARK: - Browse Commands
 
     @objc public func mdns_browse_start(_ invoke: Invoke) throws {
@@ -156,18 +171,37 @@ class IrohHttpPlugin: Plugin {
                     }
                 }
             }
-            guard let pk = txt["pk"], !pk.isEmpty else { continue }
-            currentPks.insert(pk)
+
+            // The DNS-SD instance name doubles as the node-id fallback: desktop
+            // advertisers (iroh swarm-discovery) publish the base32 endpoint id
+            // as the instance name and emit no `pk` TXT (issue #318).
+            var instanceName: String? = nil
+            if case .service(let name, _, _, _) = result.endpoint {
+                instanceName = name
+            }
+
+            // Resolve the node-id: prefer the `pk` TXT (set by mobile
+            // advertisers), then fall back to the instance name for desktop
+            // advertisers. Reject records where neither yields a valid id.
+            let nodeId: String
+            if let pk = txt["pk"], !pk.isEmpty {
+                nodeId = pk
+            } else if let name = instanceName, isValidEndpointId(name) {
+                nodeId = name
+            } else {
+                continue
+            }
+            currentPks.insert(nodeId)
 
             var addrs: [String] = []
             if let relay = txt["relay"], !relay.isEmpty { addrs.append(relay) }
 
-            if case .service(let name, _, _, _) = result.endpoint {
-                if session.knownNodes[name] != pk {
-                    session.knownNodes[name] = pk
+            if let name = instanceName {
+                if session.knownNodes[name] != nodeId {
+                    session.knownNodes[name] = nodeId
                     session.pendingEvents.append([
                         "type": "discovered",
-                        "nodeId": pk,
+                        "nodeId": nodeId,
                         "addrs": addrs,
                     ])
                 }


### PR DESCRIPTION
Closes #318

## Problem

Mobile mDNS browse (iOS `NWBrowser`, Android `NsdManager`) hard-required a `pk` TXT record to accept a discovered node. Desktop/server nodes advertised via iroh's `iroh-mdns-address-lookup` (swarm-discovery) publish the node-id as the **DNS-SD instance name** (lowercase base32 endpoint id) and emit **no `pk` TXT**. Result: both mobile browsers silently skipped every desktop-advertised node — a phone could not discover a laptop/server on the same LAN.

## Fix

Teach both mobile browse parsers to fall back to the DNS-SD instance name as the node-id when the `pk` TXT/attribute is absent, after validating it parses as a canonical iroh endpoint id. The `pk`-present path is untouched, so mobile→mobile and desktop→mobile discovery (which already rely on the `pk` TXT set by the mobile advertise path) are unchanged.

### iOS — `packages/iroh-http-tauri/ios/Sources/IrohHttpPlugin.swift`
`handleBrowseResults` now extracts the DNS-SD instance name from `result.endpoint` first, then resolves the node-id as: `pk` TXT if present and non-empty → else the instance name if it validates → else skip. Added `isValidEndpointId(_:)`.

### Android — `packages/iroh-http-tauri/android/src/main/java/com/iroh/http/IrohHttpPlugin.kt`
`onServiceResolved` resolves the node-id as: `pk` attribute if present and non-empty → else `resolved.serviceName` if it validates → else `return`. Added `isValidEndpointId(...)`.

## Base32 validation

A node-id is a 32-byte Ed25519 public key encoded as **lowercase RFC 4648 base32 without padding** (confirmed in `crates/iroh-http-core/src/encoding.rs` — `base32::Alphabet::Rfc4648Lower { padding: false }`, and the same alphabet in `packages/iroh-http-tauri/src/tests.rs`). 32 bytes → **exactly 52 chars** from the `a-z` / `2-7` alphabet. Both helpers require length `== 52` and that every char is in `a-z` or `2-7`, rejecting malformed/non-base32 names instead of crashing.

**Truncation check:** the advertise side caps instance names at 63 chars (Swift `args.pk.prefix(63)`, Kotlin `args.pk.take(63)`). A 52-char id is well under 63, so it is never truncated and the fallback always recovers the **full** id.

## Verification

- **CI-verified:** `npm run ci` is **green** — Rust/JS build, clippy, tauri crate tests (19 + 4 + 1 doc), and tauri permissions all pass. This proves the change did not break the Rust/JS build, the tauri crate, or permissions. (The `test:tauri:guest` step reports `vitest: command not found`, a local-env gap unrelated to this change; the script still exits 0.)
- **Not exercised by CI:** the iOS Swift and Android Kotlin code is not compiled/run by `npm run ci`. There is no Swift/Kotlin unit-test harness in the plugin, so no native test was added. Correctness was reasoned by reading the surrounding native code and matching the exact on-wire encoding.

### Manual cross-device repro (required before merge)

Desktop→mobile discovery of a node with **no `pk` TXT**:

1. On a desktop, start an advertiser on the LAN, e.g. via the node or deno adapter's mDNS `advertise` API (iroh swarm-discovery publishes the base32 node-id as the DNS-SD instance name, no `pk` TXT).
2. On an iOS device/simulator on the same Wi-Fi, run the tauri app and call `mdns_browse_start` / poll. **Expect:** a `discovered` event whose `nodeId` equals the desktop node's base32 id.
3. Repeat on an Android emulator/device.
4. Dial the discovered `nodeId` and confirm the connection succeeds.
5. Regression: confirm a mobile→mobile advertise (which sets the `pk` TXT) is still discovered on both platforms.

## Notes

- No version-field bumps; only the two native source files changed.
- Emitting a `pk` TXT on desktop for symmetry is blocked upstream (0.4.0 discards custom TXT) and tracked under the #310 epic — not required here.