### PR TITLE
fix(ci): build iroh-http-shared before tauri guest tests in check.sh (#321)

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -42,6 +42,12 @@ echo "  → test:tauri"
 npm run test:tauri --silent
 ok "tests (tauri)"
 
+# test:tauri:guest imports from @momics/iroh-http-shared/dist, so build it first
+# to avoid stale-dist failures after a rebase that changes the shared surface (#321).
+echo "  → build:shared"
+npm run build:shared --silent
+ok "shared"
+
 echo "  → test:tauri:guest"
 npm run test:tauri:guest --silent
 ok "tests (tauri guest-js)"


### PR DESCRIPTION
Closes #321

## Problem

`scripts/check.sh` (the `npm run ci` gate) ran `test:tauri:guest` before building `iroh-http-shared`. The guest-js vitest suite imports from `@momics/iroh-http-shared`, which resolves to `packages/iroh-http-shared/dist`. `check.sh` only built the shared package later, in its `Build` section. So a local `npm run ci` after a rebase that added new shared exports failed with runtime errors (e.g. `normaliseDiscovery is not a function`) against a stale `dist` until the developer manually ran `npm run build:shared`. Hosted CI is unaffected — this is a local-DX papercut.

## Fix

Add a `build:shared` step immediately before `test:tauri:guest`, mirroring what hosted CI does implicitly.

## Investigation

Checked every step before the `Build` section that could consume `shared/dist`:
- `test:tauri` → `cargo test` (Rust) — no dist dependency
- `test:tauri:guest` → vitest importing `@momics/iroh-http-shared/dist` — **needs dist**
- `bench:smoke` → `cargo bench` (Rust) — no dist dependency
- `check:features` → `cargo check` (Rust) — no dist dependency

Only `test:tauri:guest` consumes `shared/dist` before the Build section, so a single earlier build is sufficient. The existing `build:shared` in the Build section is kept as a harmless, cheap no-op that keeps that section self-contained.

## Verification

- **Before fix (repro):** removed `packages/iroh-http-shared/dist`, ran the guest step → failed with `Failed to resolve import "@momics/iroh-http-shared"` (mirrors the reported stale-dist failure).
- **After fix:** removed `dist` again and ran the full `npm run ci` → passed green end-to-end ("All checks passed. Ready to push.") with no manual `build:shared`.

Working tree kept clean — CI-regenerated artifacts (`packages/iroh-http-node/index.js`, `deno.lock`, `package-lock.json`) were reverted. No version-field bumps.