### PR TITLE
ci: decouple publish from build (manual tag-promoted release) (#331)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ name: Build
 #   1. Create the GitHub release with generated notes.
 #   2. Build all native binaries (Node + Deno) across 5 platforms.
 #
-# Publishing is handled by publish.yml, which triggers automatically
-# when this workflow succeeds — or can be re-triggered manually with
-# a run_id if publish fails without needing a rebuild.
+# Publishing is handled separately by publish.yml, which is promoted manually
+# (Actions → Run workflow → Publish) against a release tag once its Build and
+# Extended tests are green. It never triggers automatically.
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,20 @@
 name: Publish
 
-# Triggered automatically when the Release workflow succeeds, or manually
-# when you need to re-publish without rebuilding all 10 native targets.
+# Manually promotes a tagged release to the immutable registries (npm, crates.io,
+# JSR). Publishing NEVER auto-fires — a maintainer deliberately dispatches this
+# workflow once the tag's Build and Extended tests are green.
 #
 # Manual usage (Actions → Run workflow):
-#   run_id: the ID of the successful Release workflow run whose Node artifacts
-#           you want to publish. Find it in the URL of the release run page.
+#   tag: the release tag to promote (e.g. v0.6.0). Its commit SHA is resolved to
+#        the tag's successful `Build` run, whose native artifacts are published.
 #
 # All publish steps are idempotent — safe to run multiple times.
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types: [completed]
   workflow_dispatch:
     inputs:
-      run_id:
-        description: 'Build workflow run ID (for Node native artifacts)'
+      tag:
+        description: 'Release tag to publish (e.g. v0.6.0)'
         required: true
         type: string
       target:
@@ -35,49 +33,50 @@ jobs:
 
   # ── 0a. Resolve ref ───────────────────────────────────────────────────────────
   # Determine the EXACT commit whose artifacts we are about to publish, so the
-  # source we check out matches the native binaries built from that run. On a
-  # manual dispatch `github.sha` is the workflow's own ref (e.g. main@HEAD), NOT
-  # the commit behind `run_id` — publishing those together would ship source and
-  # binaries from different commits. Resolve the Build run's head SHA via the API
-  # and fail closed if that run did not succeed.
+  # source we check out matches the native binaries built from that run. Resolve
+  # the dispatched tag to its commit SHA, then find the tag's successful `Build`
+  # run and export that run's id so the publish jobs download the matching native
+  # artifacts. Fail closed if the tag has no successful Build run.
 
   resolve-ref:
     name: Resolve publish ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
+      build_run_id: ${{ steps.resolve.outputs.build_run_id }}
     steps:
-      - name: Resolve exact commit SHA to publish
+      - name: Resolve tag to commit SHA and Build run
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RUN_ID="${{ inputs.run_id }}"
-            echo "Resolving head SHA for Build run $RUN_ID"
-            RUN_JSON=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID")
-            SHA=$(echo "$RUN_JSON" | jq -r '.head_sha')
-            CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
-            if [ "$CONCLUSION" != "success" ]; then
-              echo "::error::Build run $RUN_ID did not succeed (conclusion=$CONCLUSION) — refusing to publish"
-              exit 1
-            fi
-          else
-            SHA="${{ github.event.workflow_run.head_sha }}"
-          fi
+          TAG="${{ inputs.tag }}"
+          echo "Resolving commit SHA for tag $TAG"
+          # Works for both lightweight and annotated tags — the commits endpoint
+          # dereferences the tag to its underlying commit.
+          SHA=$(gh api "repos/${{ github.repository }}/commits/$TAG" --jq '.sha')
           if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
-            echo "::error::Could not resolve a commit SHA to publish"
+            echo "::error::Could not resolve tag $TAG to a commit SHA"
             exit 1
           fi
-          echo "Publishing from commit $SHA"
+          echo "Tag $TAG points at commit $SHA"
+
+          echo "Looking for a successful Build run for $SHA"
+          BUILD_RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/build.yml/runs?head_sha=$SHA&per_page=100" \
+            --jq '[.workflow_runs[] | select(.status == "completed" and .conclusion == "success")] | first | .id')
+          if [ -z "$BUILD_RUN_ID" ] || [ "$BUILD_RUN_ID" = "null" ]; then
+            echo "::error::No successful Build run found for tag $TAG ($SHA) — refusing to publish"
+            exit 1
+          fi
+          echo "Publishing artifacts from Build run $BUILD_RUN_ID (commit $SHA)"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "build_run_id=$BUILD_RUN_ID" >> "$GITHUB_OUTPUT"
 
   # ── 0. Verify ─────────────────────────────────────────────────────────────────
-  # Skip automatically if triggered by a failed Release run. The extended-tests
-  # gate runs for the resolved SHA in both trigger modes — a manual re-publish
-  # must still prove the published commit passed extended tests.
+  # The extended-tests gate runs for the resolved SHA — a manual promotion must
+  # prove the published commit passed extended tests before anything ships.
 
   verify:
     name: Verify before publish
@@ -138,6 +137,7 @@ jobs:
     name: Publish Rust crates
     runs-on: ubuntu-latest
     needs: [resolve-ref, verify]
+    environment: release
     if: inputs.target == null || inputs.target == 'all' || inputs.target == 'crates'
     steps:
       - uses: actions/checkout@v6
@@ -208,6 +208,7 @@ jobs:
     name: Publish npm packages
     runs-on: ubuntu-latest
     needs: [resolve-ref, verify]
+    environment: release
     if: inputs.target == null || inputs.target == 'all' || inputs.target == 'npm'
     steps:
       - uses: actions/checkout@v6
@@ -230,7 +231,7 @@ jobs:
           pattern: node-native-*
           path: packages/iroh-http-node/artifacts/
           merge-multiple: true
-          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+          run-id: ${{ needs.resolve-ref.outputs.build_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Move artifacts into platform package dirs
@@ -294,6 +295,7 @@ jobs:
     name: Publish JSR packages
     runs-on: ubuntu-latest
     needs: [resolve-ref, verify]
+    environment: release
     if: inputs.target == null || inputs.target == 'all' || inputs.target == 'jsr'
     steps:
       - uses: actions/checkout@v6
@@ -325,7 +327,7 @@ jobs:
           pattern: deno-native-*
           path: packages/iroh-http-deno/lib/
           merge-multiple: true
-          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+          run-id: ${{ needs.resolve-ref.outputs.build_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate native checksums

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,8 +53,11 @@ jobs:
           set -euo pipefail
           TAG="${{ inputs.tag }}"
           echo "Resolving commit SHA for tag $TAG"
-          # Works for both lightweight and annotated tags — the commits endpoint
-          # dereferences the tag to its underlying commit.
+          # Dereference the tag to its underlying COMMIT sha. The commits endpoint
+          # resolves a ref (lightweight OR annotated tag) straight to the commit,
+          # so annotated tags don't leave us holding the tag-object sha. This is
+          # the same commit a tag-push run reports as its head_sha, so the Build
+          # lookup and the extended-tests verify poll below both match it.
           SHA=$(gh api "repos/${{ github.repository }}/commits/$TAG" --jq '.sha')
           if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
             echo "::error::Could not resolve tag $TAG to a commit SHA"
@@ -63,11 +66,17 @@ jobs:
           echo "Tag $TAG points at commit $SHA"
 
           echo "Looking for a successful Build run for $SHA"
+          # Pick the newest Build run that (a) ran against this exact commit,
+          # (b) succeeded, and (c) was triggered by the tag push — so a manual
+          # re-run, a branch build, or an unrelated run on the same commit can't
+          # be mis-selected. The API returns runs newest-first.
           BUILD_RUN_ID=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/build.yml/runs?head_sha=$SHA&per_page=100" \
-            --jq '[.workflow_runs[] | select(.status == "completed" and .conclusion == "success")] | first | .id')
+            "repos/${{ github.repository }}/actions/workflows/build.yml/runs?head_sha=$SHA&event=push&per_page=100" \
+            --jq "[.workflow_runs[]
+                   | select(.head_sha == \"$SHA\" and .status == \"completed\" and .conclusion == \"success\")]
+                   | first | .id")
           if [ -z "$BUILD_RUN_ID" ] || [ "$BUILD_RUN_ID" = "null" ]; then
-            echo "::error::No successful Build run found for tag $TAG ($SHA) — refusing to publish"
+            echo "::error::No successful tag-push Build run found for tag $TAG ($SHA) — refusing to publish"
             exit 1
           fi
           echo "Publishing artifacts from Build run $BUILD_RUN_ID (commit $SHA)"


### PR DESCRIPTION
Closes #331

## What & why

`publish.yml` was wired `on: workflow_run: [Build] completed`, so publishing auto-fired the instant Build finished and began polling `extended-tests.yml` for the same SHA *while those tests were still running*. Cutting **v0.6.0** raced two flakes (Node `serve handle close()` 120s timeout — #155 family; and a Tauri harness `@tauri-apps/api/core` Vite resolve failure), the `verify` gate correctly failed closed, and nothing shipped despite sound artifacts (main `ci.yml` passed fully on the same commit). The auto-trigger is the defect.

This makes publishing a **deliberate, manually-promoted step keyed off a tag**.

## Changes (`.github/workflows/publish.yml`)

- **Remove** the `workflow_run: [Build]` auto-trigger — publishing never auto-fires.
- **Switch the manual `workflow_dispatch` to a `tag` input** (was `run_id`). Kept the `target` (all/npm/crates/jsr) input.
- **`resolve-ref`** now resolves the tag → commit SHA (via `repos/{repo}/commits/{tag}`, works for lightweight + annotated tags), finds the tag's newest **successful** `build.yml` run, and exports both `sha` and `build_run_id`. Fails closed if there is no successful Build run for the tag.
- **`verify` gate kept**: polls `extended-tests.yml` for the resolved SHA (~30 min) and blocks publish if not green.
- npm/JSR `download-artifact` `run-id` now points at `needs.resolve-ref.outputs.build_run_id`.
- Publish jobs wrapped in **`environment: release`** for an optional required-reviewer gate (see below).
- Preserved `id-token: write`, npm `--provenance`, JSR OIDC, and all idempotent publish steps. **No change to what is published or how packages are built.**

Also updates a stale header comment in `build.yml` (no logic change).

## Design choices

- **Trigger: `tag`-input `workflow_dispatch`** (the issue's preferred option) rather than the `on: release: [published]` / draft-release variant — the latter isn't strictly simpler and the tag-input dispatch is the stated preference.
- **Protected environment: added `environment: release`.** Zero-risk: if the repo has no `release` environment configured, GitHub auto-creates an unprotected one (behaves as today); if a maintainer adds a required reviewer, a "Review deployments" approval button appears before anything ships. The `verify` gate runs outside the environment so the green check precedes any approval prompt.

## New release flow

Push tag → full CI (Build + Extended tests) runs → tag sits staged → maintainer runs **Actions → Publish → Run workflow** with the tag → resolve-ref + verify gate → registries publish.

## Validation

- `actionlint` clean on `publish.yml` and `build.yml`; YAML parses.
- Confirmed no other workflow depends on publish.yml's old trigger shape.
- Meticulous manual review of the `on:` block, job `needs:`, and resolve/verify/download wiring.

## Out of scope

Fixing the extended-tests flakes (#155-family `close()` timeout; tauri Vite resolve) — separate follow-up.